### PR TITLE
Add version to NPM dependencies

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
@@ -30,8 +30,8 @@ private fun Project.createJsBenchmarkCompileTask(target: JsBenchmarkTarget): Kot
         sourceSet.dependencies {
             implementation(compilation.compileDependencyFiles)
             implementation(compilation.output.allOutputs)
-            implementation(npm("benchmark"))
-            runtimeOnly(npm("source-map-support"))
+            implementation(npm("benchmark", "*"))
+            runtimeOnly(npm("source-map-support", "*"))
         }
         compileKotlinTask.apply {
             group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP


### PR DESCRIPTION
Adding version to NPM dependencies, because of removing possibility to set npm dependencies without version.
[KT-38683](https://youtrack.jetbrains.com/issue/KT-38683)