### PR TITLE
Declare system properties reads to be compatible with Gradle configuration cache

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksPlugin.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksPlugin.kt
@@ -58,7 +58,7 @@ class BenchmarksPlugin : Plugin<Project> {
                 task<DefaultTask>(it.prefixName(RUN_BENCHMARKS_TASKNAME)) {
                     group = BENCHMARKS_TASK_GROUP
                     description = "Execute all benchmarks in a project"
-                    extensions.extraProperties.set("idea.internal.test", System.getProperty("idea.active"))
+                    extensions.extraProperties.set("idea.internal.test", getSystemProperty("idea.active"))
 
                     // Force all benchmarks runner to first build all benchmarks to ensure it won't spend time
                     // running some benchmarks when other will fail to compile

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsNodeTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsNodeTasks.kt
@@ -17,7 +17,7 @@ fun Project.createJsBenchmarkExecTask(
 
         group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP
         description = "Executes benchmark for '${target.name}'"
-        extensions.extraProperties.set("idea.internal.test", System.getProperty("idea.active"))
+        extensions.extraProperties.set("idea.internal.test", project.getSystemProperty("idea.active"))
 
         val reportsDir = benchmarkReportsDir(config, target)
         val reportFile = reportsDir.resolve("${target.name}.${config.reportFileExt()}")

--- a/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
@@ -95,7 +95,7 @@ fun Project.createJvmBenchmarkExecTask(
     ) {
         group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP
         description = "Execute benchmark for '${target.name}'"
-        extensions.extraProperties.set("idea.internal.test", System.getProperty("idea.active"))
+        extensions.extraProperties.set("idea.internal.test", project.getSystemProperty("idea.active"))
 
         val benchmarkBuildDir = benchmarkBuildDir(target)
         val reportsDir = benchmarkReportsDir(config, target)

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -106,7 +106,7 @@ fun Project.createNativeBenchmarkExecTask(
     ) {
         group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP
         description = "Executes benchmark for '${target.name}'"
-        extensions.extraProperties.set("idea.internal.test", System.getProperty("idea.active"))
+        extensions.extraProperties.set("idea.internal.test", project.getSystemProperty("idea.active"))
 
         val binary =
             benchmarkCompilation.target.binaries.getExecutable(benchmarkCompilation.name, NativeBuildType.RELEASE)


### PR DESCRIPTION
Gradle reports direct system properties reads as configuration cache problems as system properties are potential build configuration inputs.
See https://docs.gradle.org/7.0/userguide/configuration_cache.html for more details