### PR TITLE
Exclude duplicate classes for Jar task

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
@@ -31,7 +31,9 @@ fun Project.createJvmBenchmarkCompileTask(target: JvmBenchmarkTarget, compileCla
         dependsOn("${target.name}${BenchmarksPlugin.BENCHMARK_COMPILE_SUFFIX}")
         conventionMapping.map("classifier") { "JMH" }
         manifest.attributes["Main-Class"] = "org.openjdk.jmh.Main"
-
+        
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        
         from(project.provider {
             compileClasspath.map {
                 when {


### PR DESCRIPTION
Hi,

This pull request attempts to fix issue #39, which causes a failure for benchmarks with complex dependencies when using Gradle 7. This issue is caused by the default `duplicatesStrategy` of the `Jar` task triggering a failure due to complex dependencies (where the same class might exist multiple times).
 
The solution is to update the `duplicatesStrategy` for the `jmhBenchmarkJar` tasks to exclude duplicate classes.

Fixes #39