### PR TITLE
Improve support for quotation marks in params

### DIFF
--- a/integration/src/test/resources/templates/kotlin-multiplatform/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/src/commonMain/kotlin/CommonBenchmark.kt
@@ -8,6 +8,9 @@ import kotlin.math.*
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {
+    @Param("""a "string" with quotes""")
+    var value = ""
+
     @Benchmark
     open fun mathBenchmark(): Double {
         return log(sqrt(3.0) * cos(3.0), 2.0)

--- a/plugin/main/src/kotlinx/benchmark/gradle/SuiteSourceGenerator.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/SuiteSourceGenerator.kt
@@ -208,15 +208,15 @@ class SuiteSourceGenerator(val title: String, val module: ModuleDescriptor, val 
                     val annotation = it.annotations.findAnnotation(FqName(paramAnnotationFQN))!!
                     val constant = annotation.argumentValue("value") 
                         ?: error("@Param annotation should have at least one default value")
-                    val values = constant.value as? List<String>
+                    val values = constant.value as? List<StringValue>
                         ?: error("@Param annotation should have at least one default value")
                     values
                 })
                 
                 val defaultParametersString = defaultParameters.entries
-                    .joinToString(prefix = "mapOf(", postfix = ")") {  
-                        "\"${it.key}\" to " + it.value.joinToString(prefix = "listOf(", postfix = ")")
-                        
+                    .joinToString(prefix = "mapOf(", postfix = ")") { (key, value) ->
+                        "\"${key}\" to ${value.joinToString(prefix = "listOf(", postfix = ")") { "\"${it.value.replace("\"", "\\\"")}\"" }}"
+
                     }
 
                 val timeUnitClass = ClassName.bestGuess(timeUnitFQN)


### PR DESCRIPTION
This PR adds support for parameters that contain quotation marks, such as `@Param("""a "string" with quotes""")` by improving code generation and report formatting.