### PR TITLE
Support JS IR

### DIFF
--- a/examples/kotlin-multiplatform/build.gradle
+++ b/examples/kotlin-multiplatform/build.gradle
@@ -10,22 +10,13 @@ allOpen {
 }
 
 kotlin {
-    jvm {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = '1.8'
-            }
-        }
-    }
-
-    js {
-        nodejs { }
-    }
-
-    macosX64 { }
-    macosArm64 { }
-    linuxX64 { }
-    mingwX64 { }
+    jvm()
+    js('jsIr', IR) { nodejs() }
+    js('jsLegacy', LEGACY) { nodejs() }
+    macosX64 {}
+    macosArm64 {}
+    linuxX64 {}
+    mingwX64 {}
 
     sourceSets.all {
         languageSettings {
@@ -42,7 +33,12 @@ kotlin {
 
         jvmMain {}
 
-        jsMain {}
+        jsMain {
+            dependsOn(commonMain)
+
+            jsIrMain.dependsOn(it)
+            jsLegacyMain.dependsOn(it)
+        }
 
         nativeMain {
             dependsOn(commonMain)
@@ -108,7 +104,8 @@ benchmark {
         register("jvm") {
             jmhVersion = "1.21"
         }
-        register("js")
+        register("jsIr")
+        register("jsLegacy")
         register("macosX64")
         register("macosArm64")
         register("linuxX64")

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -52,7 +52,8 @@ fun IncludedBuild.classpath() = projectDir.resolve("build/createClasspathManifes
 val createClasspathManifest by tasks.registering {
     dependsOn(plugin.task(":createClasspathManifest"))
     dependsOn(artifactsTask("jvm"))
-    dependsOn(artifactsTask("js"))
+    dependsOn(artifactsTask("jsIr"))
+    dependsOn(artifactsTask("jsLegacy"))
     dependsOn(artifactsTask("metadata"))
     dependsOn(artifactsTaskNativeKlibs())
 
@@ -64,7 +65,8 @@ val createClasspathManifest by tasks.registering {
             resolve("plugin-classpath.txt").writeText(plugin.classpath().resolve("plugin-classpath.txt").readText())
             resolve("runtime-metadata.txt").writeText(artifactsTask("metadata").archiveFilePath)
             resolve("runtime-jvm.txt").writeText(artifactsTask("jvm").archiveFilePath)
-            resolve("runtime-js.txt").writeText(artifactsTask("js").archiveFilePath)
+            resolve("runtime-jsIr.txt").writeText(artifactsTask("jsIr").archiveFilePath)
+            resolve("runtime-jsLegacy.txt").writeText(artifactsTask("jsLegacy").archiveFilePath)
             resolve("runtime-native.txt").writeText(artifactsTaskNativeKlibs().klibs())
         }
     }

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/ProjectBuilder.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/ProjectBuilder.kt
@@ -41,7 +41,8 @@ private val buildScript = run {
     
     def benchmarkRuntimeMetadata = files(${readFileList("runtime-metadata.txt")})
     def benchmarkRuntimeJvm = files(${readFileList("runtime-jvm.txt")})
-    def benchmarkRuntimeJs = files(${readFileList("runtime-js.txt")})
+    def benchmarkRuntimeJsIr = files(${readFileList("runtime-jsIr.txt")})
+    def benchmarkRuntimeJsLegacy = files(${readFileList("runtime-jsLegacy.txt")})
     def benchmarkRuntimeNative = files(${readFileList("runtime-native.txt")})
     """.trimIndent()
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ReportFormatTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ReportFormatTest.kt
@@ -8,6 +8,7 @@ class ReportFormatTest : GradleTest() {
     @Test
     fun testReportFormatFileNames() {
         val formats = listOf(null, "json", "csv", "scsv", "text")
+        val targets = listOf("jsIr", "jsLegacy", "jvm", "native")
 
         val runner = project("kotlin-multiplatform", true) {
             formats.forEach { format ->
@@ -20,13 +21,13 @@ class ReportFormatTest : GradleTest() {
             }
         }
 
-        formats.forEach {
-            val name = it ?: "jsonDefault"
-            val ext = it ?: "json"
+        formats.forEach { format ->
+            val name = format ?: "jsonDefault"
+            val ext = format ?: "json"
             runner.run("${name}Benchmark")
             val reports = reports(name)
-            assertEquals(3, reports.size)
-            assertEquals(setOf("js.$ext", "jvm.$ext", "native.$ext"), reports.map(File::getName).toSet())
+            assertEquals(targets.size, reports.size)
+            assertEquals(targets.map { "$it.$ext" }.toSet(), reports.map(File::getName).toSet())
         }
     }
 }

--- a/integration/src/test/resources/templates/kotlin-multiplatform/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/build.gradle
@@ -2,15 +2,9 @@ import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
 kotlin {
-    jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = '1.8'
-        }
-    }
-
-    js {
-        nodejs()
-    }
+    jvm()
+    js('jsIr', IR) { nodejs() }
+    js('jsLegacy', LEGACY) { nodejs() }
 
     if (HostManager.hostIsLinux) linuxX64('native')
     if (HostManager.hostIsMingw) mingwX64('native')
@@ -28,9 +22,14 @@ kotlin {
                 implementation(benchmarkRuntimeJvm)
             }
         }
-        jsMain {
+        jsIrMain {
             dependencies {
-                implementation(benchmarkRuntimeJs)
+                implementation(benchmarkRuntimeJsIr)
+            }
+        }
+        jsLegacyMain {
+            dependencies {
+                implementation(benchmarkRuntimeJsLegacy)
             }
         }
         nativeMain {
@@ -45,7 +44,8 @@ kotlin {
 benchmark {
     targets {
         register("jvm")
-        register("js")
+        register("jsIr")
+        register("jsLegacy")
         register("native")
     }
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
@@ -2,6 +2,8 @@ package kotlinx.benchmark.gradle
 
 import org.gradle.api.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
+import org.jetbrains.kotlin.gradle.targets.js.dsl.*
+import org.jetbrains.kotlin.gradle.targets.js.ir.*
 
 fun Project.processJsCompilation(target: JsBenchmarkTarget) {
     project.logger.info("Configuring benchmarks for '${target.name}' using Kotlin/JS")
@@ -20,6 +22,11 @@ private fun Project.createJsBenchmarkCompileTask(target: JsBenchmarkTarget): Kot
     val benchmarkBuildDir = benchmarkBuildDir(target)
     val benchmarkCompilation =
         compilation.target.compilations.create(BenchmarksPlugin.BENCHMARK_COMPILATION_NAME) as KotlinJsCompilation
+
+    (compilation.target as KotlinJsTargetDsl).apply {
+        //force to create executable: required for IR, do nothing on Legacy
+        binaries.executable(benchmarkCompilation)
+    }
 
     benchmarkCompilation.apply {
         val sourceSet = kotlinSourceSets.single()
@@ -58,6 +65,7 @@ private fun Project.createJsBenchmarkGenerateSourceTask(
         group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP
         description = "Generate JS source files for '${target.name}'"
         title = target.name
+        ir = target.compilation is KotlinJsIrCompilation
         inputClassesDirs = compilationOutput.output.allOutputs
         inputDependencies = compilationOutput.compileDependencyFiles
         outputResourcesDir = file("$benchmarkBuildDir/resources")

--- a/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
@@ -1,0 +1,102 @@
+package kotlinx.benchmark.gradle
+
+import org.jetbrains.kotlin.backend.common.serialization.metadata.*
+import org.jetbrains.kotlin.builtins.*
+import org.jetbrains.kotlin.config.*
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.incremental.components.*
+import org.jetbrains.kotlin.konan.library.*
+import org.jetbrains.kotlin.konan.util.*
+import org.jetbrains.kotlin.library.*
+import org.jetbrains.kotlin.library.impl.*
+import org.jetbrains.kotlin.library.metadata.*
+import org.jetbrains.kotlin.library.resolver.impl.*
+import org.jetbrains.kotlin.storage.*
+import org.jetbrains.kotlin.util.*
+import java.io.*
+import org.jetbrains.kotlin.konan.file.File as KonanFile
+
+internal enum class KlibResolver { JS, Native }
+
+internal fun KlibResolver.createModuleDescriptor(
+    lib: File,
+    inputDependencies: Set<File>,
+    storageManager: StorageManager
+): ModuleDescriptor {
+    val factories = klibMetadataFactories()
+
+    val library = resolveSingleFileKlib(KonanFile(lib.canonicalPath))
+
+    val module = factories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
+        library,
+        LanguageVersionSettingsImpl.DEFAULT,
+        storageManager,
+        DefaultBuiltIns.Instance,
+        null,
+        LookupTracker.DO_NOTHING
+    )
+
+    val dependencies = libraryResolver(inputDependencies).resolveWithDependencies(
+        unresolvedLibraries = library.unresolvedDependencies,
+        noStdLib = this == KlibResolver.JS,
+        noDefaultLibs = this == KlibResolver.JS,
+        noEndorsedLibs = this == KlibResolver.JS
+    )
+    val dependenciesResolved = factories.DefaultResolvedDescriptorsFactory.createResolved(
+        dependencies,
+        storageManager,
+        DefaultBuiltIns.Instance,
+        LanguageVersionSettingsImpl.DEFAULT,
+        null,
+        emptyList()
+    )
+
+    val dependenciesDescriptors = dependenciesResolved.resolvedDescriptors
+    val forwardDeclarationsModule = dependenciesResolved.forwardDeclarationsModule
+
+    module.setDependencies(listOf(module) + dependenciesDescriptors + forwardDeclarationsModule)
+    return module
+}
+
+private fun KlibResolver.klibMetadataFactories() = KlibMetadataFactories(
+    createBuiltIns = { DefaultBuiltIns.Instance },
+    flexibleTypeDeserializer = when (this) {
+        KlibResolver.JS -> DynamicTypeDeserializer
+        KlibResolver.Native -> NullFlexibleTypeDeserializer
+    }
+)
+
+private fun KlibResolver.libraryResolver(inputDependencies: Set<File>): KotlinLibraryResolverImpl<KotlinLibrary> {
+    val logger = object : Logger {
+        override fun log(message: String) {}
+        override fun error(message: String) = kotlin.error("e: $message")
+        override fun warning(message: String) {}
+        override fun fatal(message: String) = kotlin.error("e: $message")
+    }
+    val deps = inputDependencies.map(File::getCanonicalPath)
+    return KLibLibraryResolver(
+        klibs = deps,
+        knownIrProviders = when (this) {
+            KlibResolver.Native -> listOf(KLIB_INTEROP_IR_PROVIDER_IDENTIFIER)
+            KlibResolver.JS -> emptyList()
+        },
+        logger = logger
+    ).libraryResolver()
+}
+
+private class KLibLibraryResolver(
+    klibs: List<String>,
+    knownIrProviders: List<String>,
+    logger: Logger
+) : KotlinLibraryProperResolverWithAttributes<KotlinLibrary>(
+    repositories = emptyList(),
+    directLibs = klibs,
+    distributionKlib = null,
+    localKotlinDir = null,
+    skipCurrentDir = false,
+    logger = logger,
+    knownIrProviders = knownIrProviders
+) {
+    override fun libraryComponentBuilder(file: KonanFile, isDefault: Boolean): List<KotlinLibrary> =
+        createKotlinLibraryComponents(file, isDefault)
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
@@ -1,28 +1,13 @@
 package kotlinx.benchmark.gradle
 
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
+import org.gradle.api.*
+import org.gradle.api.file.*
 import org.gradle.api.tasks.*
-import org.gradle.workers.IsolationMode
-import org.gradle.workers.WorkAction
-import org.gradle.workers.WorkParameters
-import org.gradle.workers.WorkerExecutor
-import org.jetbrains.kotlin.builtins.DefaultBuiltIns
-import org.jetbrains.kotlin.config.ApiVersion
-import org.jetbrains.kotlin.config.LanguageVersion
-import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.incremental.components.LookupTracker
-import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
-import org.jetbrains.kotlin.konan.util.KlibMetadataFactories
+import org.gradle.workers.*
 import org.jetbrains.kotlin.library.*
-import org.jetbrains.kotlin.library.impl.createKotlinLibraryComponents
-import org.jetbrains.kotlin.library.metadata.NullFlexibleTypeDeserializer
-import org.jetbrains.kotlin.library.resolver.impl.libraryResolver
-import org.jetbrains.kotlin.storage.LockBasedStorageManager
-import org.jetbrains.kotlin.util.Logger
-import java.io.File
-import javax.inject.Inject
+import org.jetbrains.kotlin.storage.*
+import java.io.*
+import javax.inject.*
 
 @Suppress("UnstableApiUsage")
 @CacheableTask
@@ -63,10 +48,7 @@ open class NativeSourceGeneratorTask
     }
 }
 
-private val Builtins = DefaultBuiltIns.Instance
-private val NativeFactories = KlibMetadataFactories( { Builtins }, NullFlexibleTypeDeserializer)
-
-interface NativeSourceGeneratorWorkerParameters: WorkParameters {
+interface NativeSourceGeneratorWorkerParameters : WorkParameters {
     var title: String
     var target: String
     var inputClassesDirs: Set<File>
@@ -82,76 +64,18 @@ abstract class NativeSourceGeneratorWorker : WorkAction<NativeSourceGeneratorWor
         parameters.inputClassesDirs
             .filter { it.exists() && it.name.endsWith(KLIB_FILE_EXTENSION_WITH_DOT) }
             .forEach { lib ->
-                val module = createModuleDescriptor(parameters.target, lib, parameters.inputDependencies)
+                if (parameters.target.isEmpty())
+                    throw Exception("nativeTarget should be specified for API generator for native targets")
+
+                val storageManager = LockBasedStorageManager("Inspect")
+                val module = KlibResolver.Native.createModuleDescriptor(lib, parameters.inputDependencies, storageManager)
                 val generator = SuiteSourceGenerator(
-                        parameters.title,
+                    parameters.title,
                     module,
-                        parameters.outputSourcesDir,
+                    parameters.outputSourcesDir,
                     Platform.NATIVE
                 )
                 generator.generate()
             }
-    }
-
-
-    private fun createModuleDescriptor(nativeTarget: String, lib: File, dependencyPaths: Set<File>): ModuleDescriptor {
-        if (nativeTarget.isEmpty())
-            throw Exception("nativeTarget should be specified for API generator for native targets")
-
-        val logger = object : Logger {
-            override fun log(message: String) {}
-            override fun error(message: String) = kotlin.error("e: $message")
-            override fun warning(message: String) {}
-            override fun fatal(message: String) = kotlin.error("e: $message")
-        }
-        val pathResolver = SeveralKlibComponentResolver(dependencyPaths.map { it.canonicalPath }, logger)
-        val libraryResolver = pathResolver.libraryResolver()
-
-        val factory = NativeFactories.DefaultDeserializedDescriptorFactory
-
-        val konanFile = org.jetbrains.kotlin.konan.file.File(lib.canonicalPath)
-        val library = resolveSingleFileKlib(konanFile)
-
-        val versionSpec = LanguageVersionSettingsImpl(LanguageVersion.LATEST_STABLE, ApiVersion.LATEST_STABLE)
-        val storageManager = LockBasedStorageManager("Inspect")
-
-        val module = factory.createDescriptorOptionalBuiltIns(
-            library,
-            versionSpec,
-            storageManager,
-            Builtins,
-            null,
-            LookupTracker.DO_NOTHING
-        )
-
-        val dependencies = libraryResolver.resolveWithDependencies(library.unresolvedDependencies)
-        val dependenciesResolved = NativeFactories.DefaultResolvedDescriptorsFactory.createResolved(
-            dependencies,
-            storageManager,
-            Builtins,
-            versionSpec,
-            null,
-            emptyList()
-        )
-
-        val dependenciesDescriptors = dependenciesResolved.resolvedDescriptors
-        val forwardDeclarationsModule = dependenciesResolved.forwardDeclarationsModule
-
-        module.setDependencies(listOf(module) + dependenciesDescriptors + forwardDeclarationsModule)
-        return module
-    }
-
-    private class SeveralKlibComponentResolver(
-        klibFiles: List<String>,
-        logger: Logger
-    ) : KotlinLibraryProperResolverWithAttributes<KotlinLibrary>(
-        emptyList(), klibFiles,
-        null, null, false, logger, listOf(KLIB_INTEROP_IR_PROVIDER_IDENTIFIER)
-    ) {
-        override fun libraryComponentBuilder(
-            file: org.jetbrains.kotlin.konan.file.File,
-            isDefault: Boolean
-        ): List<KotlinLibrary> =
-            createKotlinLibraryComponents(file, isDefault)
     }
 }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -29,17 +29,8 @@ kotlin {
         }
     }
 
-    jvm {
-        compilations.all {
-            kotlinOptions {
-                jvmTarget = '1.8'
-            }
-        }
-    }
-
-    js {
-        nodejs()
-    }
+    jvm()
+    js(BOTH) { nodejs() }
 
     sourceSets.all {
         kotlin.srcDirs = ["$it.name/src"]
@@ -50,12 +41,9 @@ kotlin {
     }
 
     sourceSets {
-        commonMain {
-        }
         commonTest {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test-common'
-                implementation 'org.jetbrains.kotlin:kotlin-test-annotations-common'
+                implementation 'org.jetbrains.kotlin:kotlin-test'
             }
         }
         jvmMain {
@@ -65,18 +53,9 @@ kotlin {
         }
         jvmTest {
             dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test'
-                implementation 'org.jetbrains.kotlin:kotlin-test-junit'
                 implementation "org.openjdk.jmh:jmh-core:$jmhVersion"
             }
         }
-        jsMain {}
-        jsTest {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-test-js'
-            }
-        }
-
         nativeMain {
             dependsOn(commonMain)
         }


### PR DESCRIPTION
* fixes #30 (actualized #38)
* share klib resolving logic between JS IR and Native
* minor cleanup of buildscripts
* add support for JS IR in integration tests
* add support for JS IR in example

_Note: user should always specify, if they want to use IR or Legacy for running benchmarks. It will not work when specified BOTH, as target with BOTH can not have `executables`_