### PR TITLE
Fix `mode` config to consist with docs

### DIFF
--- a/runtime/commonMain/src/kotlinx/benchmark/RunnerConfiguration.kt
+++ b/runtime/commonMain/src/kotlinx/benchmark/RunnerConfiguration.kt
@@ -72,7 +72,7 @@ class RunnerConfiguration(config: String) {
 
     val mode = singleValueOrNull(
         "mode"
-    ) { Mode.valueOf(it) }
+    ) { it.toMode() }
 
     val nativeFork = singleValueOrNull(
         "nativeFork"


### PR DESCRIPTION
Error occurred when set `mode` to `avgt` according to docs.
```kotlin
benchmark {
    configurations {
        named("main") {
            mode="avgt"
        }
    }
```

> Exception in thread "main" java.lang.IllegalArgumentException: No enum constant org.openjdk.jmh.annotations.Mode.avgt

But set `mode='AverageTime'` works.

In order to consist with docs, I modify the `ConfigurationReader`
