### PR TITLE
Fix the unresolved reference error caused by an ambiguous reference

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
@@ -6,7 +6,6 @@ import org.jetbrains.kotlin.config.*
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.incremental.components.*
 import org.jetbrains.kotlin.konan.library.*
-import org.jetbrains.kotlin.konan.util.*
 import org.jetbrains.kotlin.library.*
 import org.jetbrains.kotlin.library.impl.*
 import org.jetbrains.kotlin.library.metadata.*


### PR DESCRIPTION
JetBrains/kotlin@f8e6c59600d5ce1b4d8d69b01409764bd7010a1b introduced compatibility typealiases for classes moved to new packages. However, because both old and new packages were star-imported, we'd have ambiguity. This is fixed here.