### PR TITLE
Fix for building large benchmark JARs

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
@@ -28,6 +28,7 @@ fun Project.createJvmBenchmarkCompileTask(target: JvmBenchmarkTarget, compileCla
     ) {
         group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP
         description = "Build JAR for JMH compiled files for '${target.name}'"
+        isZip64 = true
         dependsOn("${target.name}${BenchmarksPlugin.BENCHMARK_COMPILE_SUFFIX}")
         archiveClassifier.set("JMH")
         manifest.attributes["Main-Class"] = "org.openjdk.jmh.Main"


### PR DESCRIPTION
This should be enough to support building large JARs.

It prevents this error when building JARs with more than 65535 entries or larger than 4GB:

```
Execution failed for task ':mainBenchmarkJar'.
> archive contains more than 65535 entries.
```

Note that it may affect the compatibility of the JAR files with some old tools (see https://docs.gradle.org/current/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:zip64)

Fixes #95