### PR TITLE
[Wasm] Avoid using Any in JS interop due to KT-57136

### DIFF
--- a/runtime/wasmMain/src/kotlinx/benchmark/wasm/WasmBuiltInExecutor.kt
+++ b/runtime/wasmMain/src/kotlinx/benchmark/wasm/WasmBuiltInExecutor.kt
@@ -2,8 +2,17 @@ package kotlinx.benchmark.wasm
 
 import kotlinx.benchmark.*
 
+
+private external interface JsAny
+
 @JsFun("(p) => p")
-private external fun id(p: Any): Any
+private external fun jsId(p: JsAny): JsAny
+
+private fun id(p: Any): Any {
+    // TODO: Use dedicated type for passing Kotlin references to JS when it is available
+    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    return jsId(p as JsAny)
+}
 
 class WasmBuiltInExecutor(
     name: String,


### PR DESCRIPTION
I'm trying to implement a breaking change in Kotlin/Wasm compiler that prohibits using Any in external declarations (KT-57136)
It fails with [Project] kotlinx.benchmark TC build because we use Any in external `id` function.

I'd like to merge this workaround to master and kotlin-community/dev branches. It is a bit hacky (suppresses a warning), but should work in both 1.8.x and 1.9.x.