### PR TITLE
Align default benchmark configurations

### DIFF
--- a/runtime/commonMain/src/kotlinx/benchmark/SuiteDescriptor.kt
+++ b/runtime/commonMain/src/kotlinx/benchmark/SuiteDescriptor.kt
@@ -1,9 +1,11 @@
 package kotlinx.benchmark
 
 object DefaultDescriptorParameters {
-    val iterations = 3
-    val warmups = 3
-    val iterationTime = IterationTime(1, BenchmarkTimeUnit.SECONDS)
+    val iterations = 5
+    val warmups = 5
+    val iterationTime = IterationTime(10, BenchmarkTimeUnit.SECONDS)
+    val outputTimeUnit = BenchmarkTimeUnit.SECONDS
+    val mode = Mode.Throughput
 }
 
 open class SuiteDescriptor<T>(
@@ -20,8 +22,8 @@ open class SuiteDescriptor<T>(
     val warmups: Int = DefaultDescriptorParameters.warmups,
 
     val iterationTime: IterationTime = DefaultDescriptorParameters.iterationTime,
-    val outputTimeUnit: BenchmarkTimeUnit = BenchmarkTimeUnit.MILLISECONDS,
-    val mode: Mode = Mode.Throughput
+    val outputTimeUnit: BenchmarkTimeUnit = DefaultDescriptorParameters.outputTimeUnit,
+    val mode: Mode = DefaultDescriptorParameters.mode
 ) {
     private val _benchmarks = mutableListOf<BenchmarkDescriptor<T>>()
 


### PR DESCRIPTION
Addresses issue #75 by aligning the default warmup iteration time and count. The default number of warmup and measurement iterations is set to 5, and the default iteration time is set to 10 seconds, aligning with the JVM defaults.


