### PR TITLE
validate config values in plugin 

### DIFF
--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/BenchmarkConfiguration.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/BenchmarkConfiguration.kt
@@ -39,10 +39,8 @@ class BenchmarkConfiguration {
             mode = ${mode?.escape()}
             outputTimeUnit = ${outputTimeUnit?.escape()}
             reportFormat = ${reportFormat?.escape()}
-            includes = ${includes.map { it.escape() }.joinToString(prefix = "[", postfix = "]")}
-            excludes = ${excludes.map { it.escape() }.joinToString(prefix = "[", postfix = "]")}
-            params = ${params.map { "\"${it.key}\" to listOf(${it.value.joinToString()})" }.joinToString(prefix = "mapOf(", postfix = ")")}
-            advanced = ${advanced.map { "\"${it.key}\" to \"${it.value}\"" }.joinToString(prefix = "mapOf(", postfix = ")")}
+            includes = ${includes.map { it.escape() }}
+            excludes = ${excludes.map { it.escape() }}
         }
     """.trimIndent().split("\n")
 }

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/BenchmarkConfiguration.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/BenchmarkConfiguration.kt
@@ -8,6 +8,27 @@ class BenchmarkConfiguration {
     var mode: String? = null
     var outputTimeUnit: String? = null
     var reportFormat: String? = null
+    var includes: MutableList<String> = mutableListOf()
+    var excludes: MutableList<String> = mutableListOf()
+    var params: MutableMap<String, MutableList<Any>> = mutableMapOf()
+    var advanced: MutableMap<String, Any> = mutableMapOf()
+
+    fun include(pattern: String) {
+        includes.add(pattern)
+    }
+
+    fun exclude(pattern: String) {
+        excludes.add(pattern)
+    }
+
+    fun param(name: String, vararg value: Any) {
+        val values = params.getOrPut(name) { mutableListOf() }
+        values.addAll(value)
+    }
+
+    fun advanced(name: String, value: Any) {
+        advanced[name] = value
+    }
 
     fun lines(name: String): List<String> = """
         $name {
@@ -18,6 +39,10 @@ class BenchmarkConfiguration {
             mode = ${mode?.escape()}
             outputTimeUnit = ${outputTimeUnit?.escape()}
             reportFormat = ${reportFormat?.escape()}
+            includes = ${includes.map { it.escape() }.joinToString(prefix = "[", postfix = "]")}
+            excludes = ${excludes.map { it.escape() }.joinToString(prefix = "[", postfix = "]")}
+            params = ${params.map { "\"${it.key}\" to listOf(${it.value.joinToString()})" }.joinToString(prefix = "mapOf(", postfix = ")")}
+            advanced = ${advanced.map { "\"${it.key}\" to \"${it.value}\"" }.joinToString(prefix = "mapOf(", postfix = ")")}
         }
     """.trimIndent().split("\n")
 }

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/BenchmarkConfiguration.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/BenchmarkConfiguration.kt
@@ -41,6 +41,10 @@ class BenchmarkConfiguration {
             reportFormat = ${reportFormat?.escape()}
             includes = ${includes.map { it.escape() }}
             excludes = ${excludes.map { it.escape() }}
+            ${params.entries.joinToString(separator = "\n") { """param("${it.key}", ${it?.value?.joinToString()})""" }}
+            ${advanced.entries.joinToString(separator = "\n") {
+                """advanced("${it.key}", ${if (it.value is String) "\"${it.value}\"" else it.value})"""
+            }}
         }
     """.trimIndent().split("\n")
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -15,12 +15,12 @@ class OptionsValidationTest : GradleTest() {
                 reportFormat = "htmll"
             }
         }
-    
+
         runner.runAndFail("invalidReportFormatBenchmark") {
             assertOutputContains("Invalid report format: 'htmll'. Accepted formats: json, csv, scsv, text (e.g., reportFormat = 'json').")
         }
     }
-    
+
     @Test
     fun testIterationsValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -30,12 +30,12 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
             }
         }
-    
+
         runner.runAndFail("zeroIterationsBenchmark") {
             assertOutputContains("Invalid iterations: '0'. Expected a positive integer (e.g., iterations = 5).")
         }
     }
-    
+
     @Test
     fun testWarmupsValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -46,12 +46,12 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
             }
         }
-    
+
         runner.runAndFail("negativeWarmupsBenchmark") {
             assertOutputContains("Invalid warmups: '-1'. Expected a non-negative integer (e.g., warmups = 3).")
         }
     }
-    
+
     @Test
     fun testIterationTimeValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -61,12 +61,12 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
             }
         }
-    
+
         runner.runAndFail("zeroIterationTimeBenchmark") {
             assertOutputContains("Invalid iterationTime: '0'. Expected a positive number (e.g., iterationTime = 300).")
         }
     }
-    
+
     @Test
     fun testIterationTimeUnitValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -76,12 +76,12 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "x"
             }
         }
-    
+
         runner.runAndFail("invalidIterationTimeUnitBenchmark") {
             assertOutputContains("Invalid iterationTimeUnit: 'x'. Accepted units: seconds, s, microseconds, us, milliseconds, ms, nanoseconds, ns, minutes, m (e.g., iterationTimeUnit = 'ms').")
         }
     }
-    
+
     @Test
     fun testModeValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -92,12 +92,12 @@ class OptionsValidationTest : GradleTest() {
                 mode = "x"
             }
         }
-    
+
         runner.runAndFail("invalidModeBenchmark") {
             assertOutputContains("Invalid benchmark mode: 'x'. Accepted modes: thrpt, avgt (e.g., mode = 'thrpt').")
         }
     }
-    
+
     @Test
     fun testOutputTimeUnitValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -108,12 +108,12 @@ class OptionsValidationTest : GradleTest() {
                 outputTimeUnit = "x"
             }
         }
-    
+
         runner.runAndFail("invalidOutputTimeUnitBenchmark") {
             assertOutputContains("Invalid outputTimeUnit: 'x'. Accepted units: seconds, s, microseconds, us, milliseconds, ms, nanoseconds, ns, minutes, m (e.g., outputTimeUnit = 'ns').")
         }
     }
-    
+
     @Test
     fun testIncludesValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -124,12 +124,12 @@ class OptionsValidationTest : GradleTest() {
                 include(" ")
             }
         }
-    
+
         runner.runAndFail("blankIncludePatternBenchmark") {
             assertOutputContains("Invalid include pattern: ' '. Pattern must not be blank.")
         }
     }
-    
+
     @Test
     fun testExcludesValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -140,11 +140,11 @@ class OptionsValidationTest : GradleTest() {
                 exclude(" ")
             }
         }
-    
+
         runner.runAndFail("blankExcludePatternBenchmark") {
             assertOutputContains("Invalid exclude pattern: ' '. Pattern must not be blank.")
         }
-    }    
+    }  
 
     @Test
     fun testParamsValidation() {
@@ -171,28 +171,28 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
                 advanced(" ", "value")
             }
-        
+
             configuration("invalidNativeFork") {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
                 advanced("nativeFork", "x")
             }
-    
+
             configuration("invalidNativeGCAfterIteration") {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
                 advanced("nativeGCAfterIteration", "x")
             }
-        
+
             configuration("invalidJvmForks") {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
                 advanced("jvmForks", "-1")
             }
-        
+
             configuration("invalidJsUseBridge") {
                 iterations = 1
                 iterationTime = 100
@@ -200,7 +200,7 @@ class OptionsValidationTest : GradleTest() {
                 advanced("jsUseBridge", "x")
             }
         }
-        
+
         runner.runAndFail("blankAdvancedConfigNameBenchmark") {
             assertOutputContains("Invalid advanced config name: ' '. It must not be blank.")
         }
@@ -216,5 +216,5 @@ class OptionsValidationTest : GradleTest() {
         runner.runAndFail("invalidJsUseBridgeBenchmark") {
             assertOutputContains("Invalid value 'x' for 'jsUseBridge'. Expected a boolean value (e.g., jsUseBridge = true).")
         }
-    }      
+    }
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -6,6 +6,22 @@ import kotlin.test.*
 class OptionsValidationTest : GradleTest() {
 
     @Test
+    fun testReportFormatValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("invalidReportFormat") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                reportFormat = "htmll"
+            }
+        }
+    
+        runner.runAndFail("invalidReportFormatBenchmark") {
+            assertOutputContains("Report format 'htmll' is not supported.")
+        }
+    }
+    
+    @Test
     fun testIterationsValidation() {
         val runner = project("kotlin-multiplatform") {
             configuration("zeroIterations") {
@@ -15,10 +31,9 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("zeroIterationsBenchmark")
+        runner.runAndFail("zeroIterationsBenchmark") {
+            assertOutputContains("Iterations must be greater than 0.")
         }
-        assert(exception.message?.contains("Iterations must be greater than 0.") ?: false)
     }
     
     @Test
@@ -32,10 +47,9 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("negativeWarmupsBenchmark")
+        runner.runAndFail("negativeWarmupsBenchmark") {
+            assertOutputContains("Warmups must be equal to or greater than 0.")
         }
-        assert(exception.message?.contains("Warmups must be equal to or greater than 0.") ?: false)
     }
     
     @Test
@@ -48,10 +62,9 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("zeroIterationTimeBenchmark")
+        runner.runAndFail("zeroIterationTimeBenchmark") {
+            assertOutputContains("Iteration time must be greater than 0.")
         }
-        assert(exception.message?.contains("Iteration time must be greater than 0.") ?: false)
     }
     
     @Test
@@ -64,10 +77,9 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("invalidIterationTimeUnitBenchmark")
+        runner.runAndFail("invalidIterationTimeUnitBenchmark") {
+            assertOutputContains("Unknown time unit: x")
         }
-        assert(exception.message?.contains("Unknown time unit: x") ?: false)
     }
     
     @Test
@@ -81,10 +93,9 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("invalidModeBenchmark")
+        runner.runAndFail("invalidModeBenchmark") {
+            assertOutputContains("Benchmark mode 'x' is not supported.")
         }
-        assert(exception.message?.contains("Benchmark mode 'x' is not supported.") ?: false)
     }
     
     @Test
@@ -98,10 +109,9 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("invalidOutputTimeUnitBenchmark")
+        runner.runAndFail("invalidOutputTimeUnitBenchmark") {
+            assertOutputContains("Unknown time unit: x")
         }
-        assert(exception.message?.contains("Unknown time unit: x") ?: false)
     }
     
     @Test
@@ -115,10 +125,9 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("blankIncludePatternBenchmark")
+        runner.runAndFail("blankIncludePatternBenchmark") {
+            assertOutputContains("Include pattern should not be blank.")
         }
-        assert(exception.message?.contains("Include pattern should not be blank.") ?: false)
     }
     
     @Test
@@ -132,9 +141,40 @@ class OptionsValidationTest : GradleTest() {
             }
         }
     
-        val exception = assertFailsWith<RuntimeException> {
-            runner.run("blankExcludePatternBenchmark")
+        runner.runAndFail("blankExcludePatternBenchmark") {
+            assertOutputContains("Exclude pattern should not be blank.")
         }
-        assert(exception.message?.contains("Exclude pattern should not be blank.") ?: false)
-    }      
+    }    
+
+    @Test
+    fun testParamsValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("blankParamName") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                param(" ", 5)
+            }
+        }
+
+        runner.runAndFail("blankParamNameBenchmark") {
+            assertOutputContains("Param name should not be blank.")
+        }
+    }
+
+    @Test
+    fun testAdvancedValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("blankAdvancedConfigName") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced(" ", "value")
+            }
+        }
+
+        assertFailsWith<RuntimeException> {
+            runner.run("blankAdvancedConfigNameBenchmark")
+        }
+    }
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -17,7 +17,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("invalidReportFormatBenchmark") {
-            assertOutputContains("Report format 'htmll' is not supported.")
+            assertOutputContains("Invalid report format: 'htmll'. Accepted formats: json, csv, scsv, text (e.g., reportFormat = 'json').")
         }
     }
     
@@ -32,7 +32,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("zeroIterationsBenchmark") {
-            assertOutputContains("Iterations must be greater than 0.")
+            assertOutputContains("Invalid iterations: '0'. Expected a positive integer (e.g., iterations = 5).")
         }
     }
     
@@ -48,7 +48,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("negativeWarmupsBenchmark") {
-            assertOutputContains("Warmups must be equal to or greater than 0.")
+            assertOutputContains("Invalid warmups: '-1'. Expected a non-negative integer (e.g., warmups = 3).")
         }
     }
     
@@ -63,7 +63,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("zeroIterationTimeBenchmark") {
-            assertOutputContains("Iteration time must be greater than 0.")
+            assertOutputContains("Invalid iterationTime: '0'. Expected a positive number (e.g., iterationTime = 300).")
         }
     }
     
@@ -78,7 +78,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("invalidIterationTimeUnitBenchmark") {
-            assertOutputContains("Unknown time unit: x")
+            assertOutputContains("Invalid iterationTimeUnit: 'x'. Accepted units: seconds, s, microseconds, us, milliseconds, ms, nanoseconds, ns, minutes, m (e.g., iterationTimeUnit = 'ms').")
         }
     }
     
@@ -94,7 +94,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("invalidModeBenchmark") {
-            assertOutputContains("Benchmark mode 'x' is not supported.")
+            assertOutputContains("Invalid benchmark mode: 'x'. Accepted modes: thrpt, avgt (e.g., mode = 'thrpt').")
         }
     }
     
@@ -110,7 +110,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("invalidOutputTimeUnitBenchmark") {
-            assertOutputContains("Unknown time unit: x")
+            assertOutputContains("Invalid outputTimeUnit: 'x'. Accepted units: seconds, s, microseconds, us, milliseconds, ms, nanoseconds, ns, minutes, m (e.g., outputTimeUnit = 'ns').")
         }
     }
     
@@ -126,7 +126,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("blankIncludePatternBenchmark") {
-            assertOutputContains("Include pattern should not be blank.")
+            assertOutputContains("Invalid include pattern: ' '. Pattern must not be blank.")
         }
     }
     
@@ -142,7 +142,7 @@ class OptionsValidationTest : GradleTest() {
         }
     
         runner.runAndFail("blankExcludePatternBenchmark") {
-            assertOutputContains("Exclude pattern should not be blank.")
+            assertOutputContains("Invalid exclude pattern: ' '. Pattern must not be blank.")
         }
     }    
 
@@ -158,7 +158,7 @@ class OptionsValidationTest : GradleTest() {
         }
 
         runner.runAndFail("blankParamNameBenchmark") {
-            assertOutputContains("Param name should not be blank.")
+            assertOutputContains("Invalid param name: ' '. It must not be blank.")
         }
     }
 
@@ -171,28 +171,28 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
                 advanced(" ", "value")
             }
-    
+        
             configuration("invalidNativeFork") {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
                 advanced("nativeFork", "x")
             }
-
+    
             configuration("invalidNativeGCAfterIteration") {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
                 advanced("nativeGCAfterIteration", "x")
             }
-    
+        
             configuration("invalidJvmForks") {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
                 advanced("jvmForks", "-1")
             }
-    
+        
             configuration("invalidJsUseBridge") {
                 iterations = 1
                 iterationTime = 100
@@ -200,21 +200,21 @@ class OptionsValidationTest : GradleTest() {
                 advanced("jsUseBridge", "x")
             }
         }
-    
+        
         runner.runAndFail("blankAdvancedConfigNameBenchmark") {
-            assertOutputContains("Advanced config name should not be blank.")
+            assertOutputContains("Invalid advanced config name: ' '. It must not be blank.")
         }
         runner.runAndFail("invalidNativeForkBenchmark") {
-            assertOutputContains("Invalid value 'x' for 'nativeFork'. It should be either 'perBenchmark' or 'perIteration'.")
+            assertOutputContains("Invalid value 'x' for 'nativeFork'. Accepted values: 'perBenchmark', 'perIteration' (e.g., nativeFork = 'perBenchmark').")
         }
         runner.runAndFail("invalidNativeGCAfterIterationBenchmark") {
-            assertOutputContains("Invalid value 'x' for 'nativeGCAfterIteration'. It should be a Boolean value.")
+            assertOutputContains("Invalid value 'x' for 'nativeGCAfterIteration'. Expected a boolean value (e.g., nativeGCAfterIteration = true).")
         }
         runner.runAndFail("invalidJvmForksBenchmark") {
-            assertOutputContains("Invalid value '-1' for 'jvmForks'. It should be a non-negative integer, or 'definedByJmh'.")
+            assertOutputContains("Invalid value '-1' for 'jvmForks'. Expected a non-negative integer or 'definedByJmh' (e.g., jvmForks = 2 or jvmForks = 'definedByJmh').")
         }
         runner.runAndFail("invalidJsUseBridgeBenchmark") {
-            assertOutputContains("Invalid value 'x' for 'jsUseBridge'. It should be a Boolean value.")
+            assertOutputContains("Invalid value 'x' for 'jsUseBridge'. Expected a boolean value (e.g., jsUseBridge = true).")
         }
-    }   
+    }      
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -1,0 +1,116 @@
+package kotlinx.benchmark.integration
+
+import java.io.*
+import kotlin.test.*
+
+class OptionsValidationTest : GradleTest() {
+
+    @Test
+    fun testReportFormatValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("invalidReportFormat") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                reportFormat = "htmll"
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("invalidReportFormatBenchmark")
+        }
+    }
+    
+    @Test
+    fun testIterationsValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("zeroIterations") {
+                iterations = 0
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("zeroIterationsBenchmark")
+        }
+    }
+    
+    @Test
+    fun testWarmupsValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("negativeWarmups") {
+                iterations = 1
+                warmups = -1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("negativeWarmupsBenchmark")
+        }
+    }
+    
+    @Test
+    fun testIterationTimeValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("zeroIterationTime") {
+                iterations = 1
+                iterationTime = 0
+                iterationTimeUnit = "ms"
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("zeroIterationTimeBenchmark")
+        }
+    }
+    
+    @Test
+    fun testIterationTimeUnitValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("invalidIterationTimeUnit") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "x"
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("invalidIterationTimeUnitBenchmark")
+        }
+    }
+    
+    @Test
+    fun testModeValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("invalidMode") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                mode = "x"
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("invalidModeBenchmark")
+        }
+    }
+
+    @Test
+    fun testOutputTimeUnitValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("invalidOutputTimeUnit") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                outputTimeUnit = "x"
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("invalidOutputTimeUnitBenchmark")
+        }
+    }
+}

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -171,10 +171,50 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
                 advanced(" ", "value")
             }
-        }
+    
+            configuration("invalidNativeFork") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("nativeFork", "x")
+            }
 
-        assertFailsWith<RuntimeException> {
-            runner.run("blankAdvancedConfigNameBenchmark")
+            configuration("invalidNativeGCAfterIteration") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("nativeGCAfterIteration", "x")
+            }
+    
+            configuration("invalidJvmForks") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jvmForks", "-1")
+            }
+    
+            configuration("invalidJsUseBridge") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jsUseBridge", "x")
+            }
         }
-    }
+    
+        runner.runAndFail("blankAdvancedConfigNameBenchmark") {
+            assertOutputContains("Advanced config name should not be blank.")
+        }
+        runner.runAndFail("invalidNativeForkBenchmark") {
+            assertOutputContains("Invalid value 'x' for 'nativeFork'. It should be either 'perBenchmark' or 'perIteration'.")
+        }
+        runner.runAndFail("invalidNativeGCAfterIterationBenchmark") {
+            assertOutputContains("Invalid value 'x' for 'nativeGCAfterIteration'. It should be a Boolean value.")
+        }
+        runner.runAndFail("invalidJvmForksBenchmark") {
+            assertOutputContains("Invalid value '-1' for 'jvmForks'. It should be a non-negative integer, or 'definedByJmh'.")
+        }
+        runner.runAndFail("invalidJsUseBridgeBenchmark") {
+            assertOutputContains("Invalid value 'x' for 'jsUseBridge'. It should be a Boolean value.")
+        }
+    }   
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -6,22 +6,6 @@ import kotlin.test.*
 class OptionsValidationTest : GradleTest() {
 
     @Test
-    fun testReportFormatValidation() {
-        val runner = project("kotlin-multiplatform") {
-            configuration("invalidReportFormat") {
-                iterations = 1
-                iterationTime = 100
-                iterationTimeUnit = "ms"
-                reportFormat = "htmll"
-            }
-        }
-        
-        assertFailsWith<RuntimeException> {
-            runner.run("invalidReportFormatBenchmark")
-        }
-    }
-    
-    @Test
     fun testIterationsValidation() {
         val runner = project("kotlin-multiplatform") {
             configuration("zeroIterations") {
@@ -30,10 +14,11 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("zeroIterationsBenchmark")
         }
+        assert(exception.message?.contains("Iterations must be greater than 0.") ?: false)
     }
     
     @Test
@@ -46,10 +31,11 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("negativeWarmupsBenchmark")
         }
+        assert(exception.message?.contains("Warmups must be equal to or greater than 0.") ?: false)
     }
     
     @Test
@@ -61,10 +47,11 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("zeroIterationTimeBenchmark")
         }
+        assert(exception.message?.contains("Iteration time must be greater than 0.") ?: false)
     }
     
     @Test
@@ -76,10 +63,11 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "x"
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("invalidIterationTimeUnitBenchmark")
         }
+        assert(exception.message?.contains("Unknown time unit: x") ?: false)
     }
     
     @Test
@@ -92,12 +80,13 @@ class OptionsValidationTest : GradleTest() {
                 mode = "x"
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("invalidModeBenchmark")
         }
+        assert(exception.message?.contains("Benchmark mode 'x' is not supported.") ?: false)
     }
-
+    
     @Test
     fun testOutputTimeUnitValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -108,12 +97,13 @@ class OptionsValidationTest : GradleTest() {
                 outputTimeUnit = "x"
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("invalidOutputTimeUnitBenchmark")
         }
+        assert(exception.message?.contains("Unknown time unit: x") ?: false)
     }
-
+    
     @Test
     fun testIncludesValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -124,10 +114,11 @@ class OptionsValidationTest : GradleTest() {
                 include(" ")
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("blankIncludePatternBenchmark")
         }
+        assert(exception.message?.contains("Include pattern should not be blank.") ?: false)
     }
     
     @Test
@@ -140,41 +131,10 @@ class OptionsValidationTest : GradleTest() {
                 exclude(" ")
             }
         }
-        
-        assertFailsWith<RuntimeException> {
+    
+        val exception = assertFailsWith<RuntimeException> {
             runner.run("blankExcludePatternBenchmark")
         }
-    }
-    
-    @Test
-    fun testParamsValidation() {
-        val runner = project("kotlin-multiplatform") {
-            configuration("blankParamName") {
-                iterations = 1
-                iterationTime = 100
-                iterationTimeUnit = "ms"
-                param(" ", "value")
-            }
-        }
-        
-        assertFailsWith<RuntimeException> {
-            runner.run("blankParamNameBenchmark")
-        }
-    }
-    
-    @Test
-    fun testAdvancedValidation() {
-        val runner = project("kotlin-multiplatform") {
-            configuration("blankAdvancedConfigName") {
-                iterations = 1
-                iterationTime = 100
-                iterationTimeUnit = "ms"
-                advanced(" ", "value")
-            }
-        }
-        
-        assertFailsWith<RuntimeException> {
-            runner.run("blankAdvancedConfigNameBenchmark")
-        }
-    }    
+        assert(exception.message?.contains("Exclude pattern should not be blank.") ?: false)
+    }      
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -113,4 +113,68 @@ class OptionsValidationTest : GradleTest() {
             runner.run("invalidOutputTimeUnitBenchmark")
         }
     }
+
+    @Test
+    fun testIncludesValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("blankIncludePattern") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                include(" ")
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("blankIncludePatternBenchmark")
+        }
+    }
+    
+    @Test
+    fun testExcludesValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("blankExcludePattern") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                exclude(" ")
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("blankExcludePatternBenchmark")
+        }
+    }
+    
+    @Test
+    fun testParamsValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("blankParamName") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                param(" ", "value")
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("blankParamNameBenchmark")
+        }
+    }
+    
+    @Test
+    fun testAdvancedValidation() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("blankAdvancedConfigName") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced(" ", "value")
+            }
+        }
+        
+        assertFailsWith<RuntimeException> {
+            runner.run("blankAdvancedConfigNameBenchmark")
+        }
+    }    
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
@@ -6,64 +6,12 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 
 open class BenchmarkConfiguration(val extension: BenchmarksExtension, val name: String) {
     var iterations: Int? = null
-        set(value) {
-            value?.let {
-                require(it > 0) { "Invalid iterations: '$it'. Expected a positive integer (e.g., iterations = 5)." }
-            }
-            field = value
-        }
-
     var warmups: Int? = null
-        set(value) {
-            value?.let {
-                require(it >= 0) { "Invalid warmups: '$it'. Expected a non-negative integer (e.g., warmups = 3)." }
-            }
-            field = value
-        }
-
     var iterationTime: Long? = null
-        set(value) {
-            value?.let {
-                require(it > 0) { "Invalid iterationTime: '$it'. Expected a positive number (e.g., iterationTime = 300)." }
-            }
-            field = value
-        }
-
     var iterationTimeUnit: String? = null
-        set(value) {
-            value?.let {
-                val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
-                require(it.toLowerCase() in validTimeUnits) { "Invalid iterationTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., iterationTimeUnit = 'ms')." }
-            }
-            field = value
-        }
-
     var mode: String? = null
-        set(value) {
-            value?.let {
-                val validModes = setOf("thrpt", "avgt")
-                require(it.toLowerCase() in validModes) { "Invalid benchmark mode: '$it'. Accepted modes: ${validModes.joinToString(", ")} (e.g., mode = 'thrpt')." }
-            }
-            field = value
-        }
-
     var outputTimeUnit: String? = null
-        set(value) {
-            value?.let {
-                val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
-                require(it.toLowerCase() in validTimeUnits) { "Invalid outputTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., outputTimeUnit = 'ns')." }
-            }
-            field = value
-        }
-
     var reportFormat: String? = null
-        set(value) {
-            value?.let {
-                val validFormats = setOf("json", "csv", "scsv", "text")
-                require(it.toLowerCase() in validFormats) { "Invalid report format: '$it'. Accepted formats: ${validFormats.joinToString(", ")} (e.g., reportFormat = 'json')." }
-            }
-            field = value
-        }
 
     var includes: MutableList<String> = mutableListOf()
     var excludes: MutableList<String> = mutableListOf()
@@ -71,50 +19,21 @@ open class BenchmarkConfiguration(val extension: BenchmarksExtension, val name: 
     var advanced: MutableMap<String, Any?> = mutableMapOf()
 
     fun include(pattern: String) {
-        require(pattern.isNotBlank()) { "Invalid include pattern: '$pattern'. Pattern must not be blank." }
         includes.add(pattern)
     }
 
     fun exclude(pattern: String) {
-        require(pattern.isNotBlank()) { "Invalid exclude pattern: '$pattern'. Pattern must not be blank." }
         excludes.add(pattern)
     }
 
     fun param(name: String, vararg value: Any?) {
-        require(name.isNotBlank()) { "Invalid param name: '$name'. It must not be blank." }
-        require(value.isNotEmpty()) { "Param '$name' has no values. At least one value is required." }
         val values = params.getOrPut(name) { mutableListOf() }
         values.addAll(value)
     }
 
     fun advanced(name: String, value: Any?) {
-        require(name.isNotBlank()) { "Invalid advanced config param: '$name'. It must not be blank." }
-        require(value.toString().isNotBlank()) { "Invalid value for param '$name': '$value'. Value should not be blank." }
-        
-        when (name) {
-            "nativeFork" -> {
-                val validValues = setOf("perbenchmark", "periteration")
-                require(value.toString().toLowerCase() in validValues) {
-                    "Invalid value for 'nativeFork': '$value'. Accepted values: ${validValues.joinToString(", ")}."
-                }
-            }
-            "nativeGCAfterIteration" -> require(value is Boolean) {
-                "Invalid value for 'nativeGCAfterIteration': '$value'. Expected a Boolean value."
-            }
-            "jvmForks" -> {
-                val intValue = value.toString().toIntOrNull()
-                require(intValue != null && intValue >= 0 || value.toString().toLowerCase() == "definedbyjmh") {
-                    "Invalid value for 'jvmForks': '$value'. Expected a non-negative integer or 'definedByJmh'."
-                }
-            }
-            "jsUseBridge" -> require(value is Boolean) {
-                "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
-            }
-            else -> throw IllegalArgumentException("Invalid advanced config parameter: '$name'. Accepted parameters: 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', 'jsUseBridge'.")
-        }
-        
         advanced[name] = value
-    }    
+    }
 
     fun capitalizedName() = if (name == "main") "" else name.capitalize()
     fun prefixName(suffix: String) = if (name == "main") suffix else name + suffix.capitalize()

--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
@@ -6,12 +6,64 @@ import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 
 open class BenchmarkConfiguration(val extension: BenchmarksExtension, val name: String) {
     var iterations: Int? = null
+        set(value) {
+            value?.let {
+                require(it > 0) { "Invalid iterations: '$it'. Expected a positive integer (e.g., iterations = 5)." }
+            }
+            field = value
+        }
+
     var warmups: Int? = null
+        set(value) {
+            value?.let {
+                require(it >= 0) { "Invalid warmups: '$it'. Expected a non-negative integer (e.g., warmups = 3)." }
+            }
+            field = value
+        }
+
     var iterationTime: Long? = null
+        set(value) {
+            value?.let {
+                require(it > 0) { "Invalid iterationTime: '$it'. Expected a positive number (e.g., iterationTime = 300)." }
+            }
+            field = value
+        }
+
     var iterationTimeUnit: String? = null
+        set(value) {
+            value?.let {
+                val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
+                require(it.toLowerCase() in validTimeUnits) { "Invalid iterationTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., iterationTimeUnit = 'ms')." }
+            }
+            field = value
+        }
+
     var mode: String? = null
+        set(value) {
+            value?.let {
+                val validModes = setOf("thrpt", "avgt")
+                require(it.toLowerCase() in validModes) { "Invalid benchmark mode: '$it'. Accepted modes: ${validModes.joinToString(", ")} (e.g., mode = 'thrpt')." }
+            }
+            field = value
+        }
+
     var outputTimeUnit: String? = null
+        set(value) {
+            value?.let {
+                val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
+                require(it.toLowerCase() in validTimeUnits) { "Invalid outputTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., outputTimeUnit = 'ns')." }
+            }
+            field = value
+        }
+
     var reportFormat: String? = null
+        set(value) {
+            value?.let {
+                val validFormats = setOf("json", "csv", "scsv", "text")
+                require(it.toLowerCase() in validFormats) { "Invalid report format: '$it'. Accepted formats: ${validFormats.joinToString(", ")} (e.g., reportFormat = 'json')." }
+            }
+            field = value
+        }
 
     var includes: MutableList<String> = mutableListOf()
     var excludes: MutableList<String> = mutableListOf()
@@ -19,21 +71,50 @@ open class BenchmarkConfiguration(val extension: BenchmarksExtension, val name: 
     var advanced: MutableMap<String, Any?> = mutableMapOf()
 
     fun include(pattern: String) {
+        require(pattern.isNotBlank()) { "Invalid include pattern: '$pattern'. Pattern must not be blank." }
         includes.add(pattern)
     }
 
     fun exclude(pattern: String) {
+        require(pattern.isNotBlank()) { "Invalid exclude pattern: '$pattern'. Pattern must not be blank." }
         excludes.add(pattern)
     }
 
     fun param(name: String, vararg value: Any?) {
+        require(name.isNotBlank()) { "Invalid param name: '$name'. It must not be blank." }
+        require(value.isNotEmpty()) { "Param '$name' has no values. At least one value is required." }
         val values = params.getOrPut(name) { mutableListOf() }
         values.addAll(value)
     }
 
     fun advanced(name: String, value: Any?) {
+        require(name.isNotBlank()) { "Invalid advanced config param: '$name'. It must not be blank." }
+        require(value.toString().isNotBlank()) { "Invalid value for param '$name': '$value'. Value should not be blank." }
+        
+        when (name) {
+            "nativeFork" -> {
+                val validValues = setOf("perbenchmark", "periteration")
+                require(value.toString().toLowerCase() in validValues) {
+                    "Invalid value for 'nativeFork': '$value'. Accepted values: ${validValues.joinToString(", ")}."
+                }
+            }
+            "nativeGCAfterIteration" -> require(value is Boolean) {
+                "Invalid value for 'nativeGCAfterIteration': '$value'. Expected a Boolean value."
+            }
+            "jvmForks" -> {
+                val intValue = value.toString().toIntOrNull()
+                require(intValue != null && intValue >= 0 || value.toString().toLowerCase() == "definedbyjmh") {
+                    "Invalid value for 'jvmForks': '$value'. Expected a non-negative integer or 'definedByJmh'."
+                }
+            }
+            "jsUseBridge" -> require(value is Boolean) {
+                "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
+            }
+            else -> throw IllegalArgumentException("Invalid advanced config parameter: '$name'. Accepted parameters: 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', 'jsUseBridge'.")
+        }
+        
         advanced[name] = value
-    }
+    }    
 
     fun capitalizedName() = if (name == "main") "" else name.capitalize()
     fun prefixName(suffix: String) = if (name == "main") suffix else name + suffix.capitalize()

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -102,7 +102,6 @@ fun writeParameters(
     format: String,
     config: BenchmarkConfiguration
 ): File {
-    validateConfig(config)
     val file = createTempFile("benchmarks")
     file.writeText(buildString {
         appendLine("name:$name")
@@ -130,113 +129,6 @@ fun writeParameters(
         }
     })
     return file
-}
-
-private fun validateConfig(config: BenchmarkConfiguration) {
-    config.reportFormat?.let {
-        val validFormats = setOf("json", "csv", "scsv", "text")
-        require(it.toLowerCase() in validFormats) {
-            "Invalid report format: '$it'. Accepted formats: ${validFormats.joinToString(", ")} (e.g., reportFormat = 'json')."
-        }
-    }
-
-    config.iterations?.let {
-        require(it > 0) {
-            "Invalid iterations: '$it'. Expected a positive integer (e.g., iterations = 5)."
-        }
-    }
-
-    config.warmups?.let {
-        require(it >= 0) {
-            "Invalid warmups: '$it'. Expected a non-negative integer (e.g., warmups = 3)."
-        }
-    }
-
-    config.iterationTime?.let {
-        require(it > 0) {
-            "Invalid iterationTime: '$it'. Expected a positive number (e.g., iterationTime = 300)."
-        }
-        require(config.iterationTimeUnit != null) {
-            "Missing iterationTimeUnit. Please provide iterationTimeUnit when specifying iterationTime."
-        }
-    }
-    
-    config.iterationTimeUnit?.let {
-        val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
-        require(it.toLowerCase() in validTimeUnits) {
-            "Invalid iterationTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., iterationTimeUnit = 'ms')."
-        }
-        require(config.iterationTime != null) {
-            "Missing iterationTime. Please provide iterationTime when specifying iterationTimeUnit."
-        }
-    }
-    
-    config.mode?.let {
-        val validModes = setOf("thrpt", "avgt")
-        require(it.toLowerCase() in validModes) {
-            "Invalid benchmark mode: '$it'. Accepted modes: ${validModes.joinToString(", ")} (e.g., mode = 'thrpt')."
-        }
-    }
-    
-    config.outputTimeUnit?.let {
-        val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
-        require(it.toLowerCase() in validTimeUnits) {
-            "Invalid outputTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., outputTimeUnit = 'ns')."
-        }
-    }    
-
-    config.includes.forEach { pattern ->
-        require(pattern.isNotBlank()) {
-            "Invalid include pattern: '$pattern'. Pattern must not be blank."
-        }
-    }
-
-    config.excludes.forEach { pattern ->
-        require(pattern.isNotBlank()) {
-            "Invalid exclude pattern: '$pattern'. Pattern must not be blank."
-        }
-    }
-
-    config.params.forEach { (param, values) ->
-        require(param.isNotBlank()) {
-            "Invalid param name: '$param'. It must not be blank."
-        }
-        require(values.isNotEmpty()) {
-            "Param '$param' has no values. At least one value is required."
-        }
-    }
-
-    config.advanced.forEach { (param, value) ->
-        println("Validating advanced param: $param with value: $value")
-        require(param.isNotBlank()) {
-            "Invalid advanced config param: '$param'. It must not be blank."
-        }
-        require(value.toString().isNotBlank()) {
-            "Invalid value for param '$param': '$value'. Value should not be blank."
-        }
-
-        when (param) {
-            "nativeFork" -> {
-                val validValues = setOf("perbenchmark", "periteration")
-                require(value.toString().toLowerCase() in validValues) {
-                    "Invalid value for 'nativeFork': '$value'. Accepted values: ${validValues.joinToString(", ")}."
-                }
-            }
-            "nativeGCAfterIteration" -> require(value is Boolean) {
-                "Invalid value for 'nativeGCAfterIteration': '$value'. Expected a Boolean value."
-            }
-            "jvmForks" -> {
-                val intValue = value.toString().toIntOrNull()
-                require(intValue != null && intValue >= 0 || value.toString().toLowerCase() == "definedbyjmh") {
-                    "Invalid value for 'jvmForks': '$value'. Expected a non-negative integer or 'definedByJmh'."
-                }
-            }
-            "jsUseBridge" -> require(value is Boolean) {
-                "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
-            }
-            else -> throw IllegalArgumentException("Invalid advanced config parameter: '$param'. Accepted parameters: 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', 'jsUseBridge'.")
-        }
-    }
 }
 
 internal val Gradle.isConfigurationCacheAvailable

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -194,14 +194,12 @@ private fun validateConfig(config: BenchmarkConfiguration) {
         }
     }
 
-    // Validate exclude
     config.excludes.forEach {
         require(it.isNotBlank()) {
             "Exclude pattern should not be blank."
         }
     }
 
-    // Validate params
     config.params.forEach { (param, values) ->
         require(param.isNotBlank()) {
             "Param name should not be blank."
@@ -211,7 +209,6 @@ private fun validateConfig(config: BenchmarkConfiguration) {
         }
     }
 
-    // Validate advanced
     config.advanced.forEach { (param, value) ->
         println("Validating advanced param: $param with value: $value")
         require(param.isNotBlank()) {
@@ -221,7 +218,6 @@ private fun validateConfig(config: BenchmarkConfiguration) {
             "Value for advanced config '$param' should not be blank."
         }
 
-        // Specific advanced config validations
         when (param) {
             "nativeFork" -> require(value.toString().toLowerCase() in setOf("perbenchmark", "periteration")) {
                 "Invalid value '$value' for 'nativeFork'. It should be either 'perBenchmark' or 'perIteration'."

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -134,106 +134,109 @@ fun writeParameters(
 
 private fun validateConfig(config: BenchmarkConfiguration) {
     config.reportFormat?.let {
-        require(it.toLowerCase() in setOf("json", "csv", "scsv", "text")) {
-            "Unrecognized report format '$it'. Please use one of the following: 'json', 'csv', 'scsv', or 'text'."
+        val validFormats = setOf("json", "csv", "scsv", "text")
+        require(it.toLowerCase() in validFormats) {
+            "Invalid report format: '$it'. Accepted formats: ${validFormats.joinToString(", ")} (e.g., reportFormat = 'json')."
         }
     }
 
     config.iterations?.let {
         require(it > 0) {
-            "Invalid iterations '$it'. Please provide a positive number (e.g., iterations = 5)."
+            "Invalid iterations: '$it'. Expected a positive integer (e.g., iterations = 5)."
         }
     }
 
     config.warmups?.let {
         require(it >= 0) {
-            "Invalid warmups '$it'. Please provide a non-negative number (e.g., warmups = 3)."
+            "Invalid warmups: '$it'. Expected a non-negative integer (e.g., warmups = 3)."
         }
     }
 
     config.iterationTime?.let {
         require(it > 0) {
-            "Invalid iterationTime '$it'. Please provide a positive number (e.g., iterationTime = 1)."
+            "Invalid iterationTime: '$it'. Expected a positive number (e.g., iterationTime = 300)."
         }
         require(config.iterationTimeUnit != null) {
-            "Missing iterationTimeUnit. Please provide the iterationTimeUnit when iterationTime is given."
+            "Missing iterationTimeUnit. Please provide iterationTimeUnit when specifying iterationTime."
         }
     }
     
     config.iterationTimeUnit?.let {
         val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
         require(it.toLowerCase() in validTimeUnits) {
-            "Invalid iterationTimeUnit '$it'. Valid units: ${validTimeUnits.joinToString(", ")}."
+            "Invalid iterationTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., iterationTimeUnit = 'ms')."
         }
         require(config.iterationTime != null) {
-            "Missing iterationTime. Please provide the iterationTime when iterationTimeUnit is given."
+            "Missing iterationTime. Please provide iterationTime when specifying iterationTimeUnit."
         }
     }
     
     config.mode?.let {
         val validModes = setOf("thrpt", "avgt")
         require(it.toLowerCase() in validModes) {
-            "Unsupported benchmark mode '$it'. Valid modes: ${validModes.joinToString(", ")}."
+            "Invalid benchmark mode: '$it'. Accepted modes: ${validModes.joinToString(", ")} (e.g., mode = 'thrpt')."
         }
     }
     
     config.outputTimeUnit?.let {
         val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
         require(it.toLowerCase() in validTimeUnits) {
-            "Invalid outputTimeUnit '$it'. Valid units: ${validTimeUnits.joinToString(", ")}."
+            "Invalid outputTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., outputTimeUnit = 'ns')."
         }
     }    
 
-    config.includes.forEach {
-        require(it.isNotBlank()) {
-            "Include pattern must not be blank."
+    config.includes.forEach { pattern ->
+        require(pattern.isNotBlank()) {
+            "Invalid include pattern: '$pattern'. Pattern must not be blank."
         }
     }
 
-    config.excludes.forEach {
-        require(it.isNotBlank()) {
-            "Exclude pattern must not be blank."
+    config.excludes.forEach { pattern ->
+        require(pattern.isNotBlank()) {
+            "Invalid exclude pattern: '$pattern'. Pattern must not be blank."
         }
     }
 
     config.params.forEach { (param, values) ->
         require(param.isNotBlank()) {
-            "Param name must not be blank."
+            "Invalid param name: '$param'. It must not be blank."
         }
         require(values.isNotEmpty()) {
-            "No values provided for param '$param'. At least one value is required."
+            "Param '$param' has no values. At least one value is required."
         }
     }
 
     config.advanced.forEach { (param, value) ->
         println("Validating advanced param: $param with value: $value")
         require(param.isNotBlank()) {
-            "Invalid param '$param'. Advanced config name should not be blank."
+            "Invalid advanced config param: '$param'. It must not be blank."
         }
         require(value.toString().isNotBlank()) {
-            "Invalid value '$value' for param '$param'. Advanced config value should not be blank."
+            "Invalid value for param '$param': '$value'. Value should not be blank."
         }
-    
+
         when (param) {
-            "nativeFork" -> require(value.toString().toLowerCase() in setOf("perbenchmark", "periteration")) {
-                "Invalid value '$value' for 'nativeFork'. Acceptable values are 'perBenchmark' or 'perIteration'."
+            "nativeFork" -> {
+                val validValues = setOf("perbenchmark", "periteration")
+                require(value.toString().toLowerCase() in validValues) {
+                    "Invalid value for 'nativeFork': '$value'. Accepted values: ${validValues.joinToString(", ")}."
+                }
             }
             "nativeGCAfterIteration" -> require(value is Boolean) {
-                "Invalid value '$value' for 'nativeGCAfterIteration'. Expecting a Boolean value."
+                "Invalid value for 'nativeGCAfterIteration': '$value'. Expected a Boolean value."
             }
             "jvmForks" -> {
                 val intValue = value.toString().toIntOrNull()
                 require(intValue != null && intValue >= 0 || value.toString().toLowerCase() == "definedbyjmh") {
-                    "Invalid value '$value' for 'jvmForks'. Acceptable values are a non-negative integer, or 'definedByJmh'."
+                    "Invalid value for 'jvmForks': '$value'. Expected a non-negative integer or 'definedByJmh'."
                 }
             }
             "jsUseBridge" -> require(value is Boolean) {
-                "Invalid value '$value' for 'jsUseBridge'. Expecting a Boolean value."
+                "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
             }
-            else -> throw IllegalArgumentException("Invalid advanced config parameter '$param'. Valid parameters include 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', and 'jsUseBridge'.")
+            else -> throw IllegalArgumentException("Invalid advanced config parameter: '$param'. Accepted parameters: 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', 'jsUseBridge'.")
         }
     }
-    
 }
 
 internal val Gradle.isConfigurationCacheAvailable

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -102,6 +102,7 @@ fun writeParameters(
     format: String,
     config: BenchmarkConfiguration
 ): File {
+    validateConfig(config)
     val file = createTempFile("benchmarks")
     file.writeText(buildString {
         appendLine("name:$name")
@@ -129,6 +130,113 @@ fun writeParameters(
         }
     })
     return file
+}
+
+private fun validateConfig(config: BenchmarkConfiguration) {
+    config.reportFormat?.let {
+        val validFormats = setOf("json", "csv", "scsv", "text")
+        require(it.toLowerCase() in validFormats) {
+            "Invalid report format: '$it'. Accepted formats: ${validFormats.joinToString(", ")} (e.g., reportFormat = 'json')."
+        }
+    }
+
+    config.iterations?.let {
+        require(it > 0) {
+            "Invalid iterations: '$it'. Expected a positive integer (e.g., iterations = 5)."
+        }
+    }
+
+    config.warmups?.let {
+        require(it >= 0) {
+            "Invalid warmups: '$it'. Expected a non-negative integer (e.g., warmups = 3)."
+        }
+    }
+
+    config.iterationTime?.let {
+        require(it > 0) {
+            "Invalid iterationTime: '$it'. Expected a positive number (e.g., iterationTime = 300)."
+        }
+        require(config.iterationTimeUnit != null) {
+            "Missing iterationTimeUnit. Please provide iterationTimeUnit when specifying iterationTime."
+        }
+    }
+
+    config.iterationTimeUnit?.let {
+        val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
+        require(it.toLowerCase() in validTimeUnits) {
+            "Invalid iterationTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., iterationTimeUnit = 'ms')."
+        }
+        require(config.iterationTime != null) {
+            "Missing iterationTime. Please provide iterationTime when specifying iterationTimeUnit."
+        }
+    }
+
+    config.mode?.let {
+        val validModes = setOf("thrpt", "avgt")
+        require(it.toLowerCase() in validModes) {
+            "Invalid benchmark mode: '$it'. Accepted modes: ${validModes.joinToString(", ")} (e.g., mode = 'thrpt')."
+        }
+    }
+    
+    config.outputTimeUnit?.let {
+        val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
+        require(it.toLowerCase() in validTimeUnits) {
+            "Invalid outputTimeUnit: '$it'. Accepted units: ${validTimeUnits.joinToString(", ")} (e.g., outputTimeUnit = 'ns')."
+        }
+    }    
+
+    config.includes.forEach { pattern ->
+        require(pattern.isNotBlank()) {
+            "Invalid include pattern: '$pattern'. Pattern must not be blank."
+        }
+    }
+
+    config.excludes.forEach { pattern ->
+        require(pattern.isNotBlank()) {
+            "Invalid exclude pattern: '$pattern'. Pattern must not be blank."
+        }
+    }
+
+    config.params.forEach { (param, values) ->
+        require(param.isNotBlank()) {
+            "Invalid param name: '$param'. It must not be blank."
+        }
+        require(values.isNotEmpty()) {
+            "Param '$param' has no values. At least one value is required."
+        }
+    }
+
+    config.advanced.forEach { (param, value) ->
+        println("Validating advanced param: $param with value: $value")
+        require(param.isNotBlank()) {
+            "Invalid advanced config param: '$param'. It must not be blank."
+        }
+        require(value.toString().isNotBlank()) {
+            "Invalid value for param '$param': '$value'. Value should not be blank."
+        }
+
+        when (param) {
+            "nativeFork" -> {
+                val validValues = setOf("perbenchmark", "periteration")
+                require(value.toString().toLowerCase() in validValues) {
+                    "Invalid value for 'nativeFork': '$value'. Accepted values: ${validValues.joinToString(", ")}."
+                }
+            }
+            "nativeGCAfterIteration" -> require(value is Boolean) {
+                "Invalid value for 'nativeGCAfterIteration': '$value'. Expected a Boolean value."
+            }
+            "jvmForks" -> {
+                val intValue = value.toString().toIntOrNull()
+                require(intValue != null && intValue >= 0 || value.toString().toLowerCase() == "definedbyjmh") {
+                    "Invalid value for 'jvmForks': '$value'. Expected a non-negative integer or 'definedByJmh'."
+                }
+            }
+            "jsUseBridge" -> require(value is Boolean) {
+                "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
+            }
+            else -> throw IllegalArgumentException("Invalid advanced config parameter: '$param'. Accepted parameters: 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', 'jsUseBridge'.")
+        }
+    }
 }
 
 internal val Gradle.isConfigurationCacheAvailable

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -135,108 +135,105 @@ fun writeParameters(
 private fun validateConfig(config: BenchmarkConfiguration) {
     config.reportFormat?.let {
         require(it.toLowerCase() in setOf("json", "csv", "scsv", "text")) {
-            "Report format '$it' is not supported."
+            "Unrecognized report format '$it'. Please use one of the following: 'json', 'csv', 'scsv', or 'text'."
         }
     }
 
     config.iterations?.let {
         require(it > 0) {
-            "Iterations must be greater than 0."
+            "Invalid iterations '$it'. Please provide a positive number (e.g., iterations = 5)."
         }
     }
 
     config.warmups?.let {
         require(it >= 0) {
-            "Warmups must be equal to or greater than 0."
+            "Invalid warmups '$it'. Please provide a non-negative number (e.g., warmups = 3)."
         }
     }
 
     config.iterationTime?.let {
         require(it > 0) {
-            "Iteration time must be greater than 0."
+            "Invalid iterationTime '$it'. Please provide a positive number (e.g., iterationTime = 1)."
         }
         require(config.iterationTimeUnit != null) {
-            "If iterationTime is provided, iterationTimeUnit must also be provided."
+            "Missing iterationTimeUnit. Please provide the iterationTimeUnit when iterationTime is given."
         }
     }
     
     config.iterationTimeUnit?.let {
-        require(it.toLowerCase() in setOf(
-            "seconds", "s", "microseconds", "us", "milliseconds", "ms",
-            "nanoseconds", "ns", "minutes", "m"
-        )) {
-            "Unknown time unit: $it"
+        val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
+        require(it.toLowerCase() in validTimeUnits) {
+            "Invalid iterationTimeUnit '$it'. Valid units: ${validTimeUnits.joinToString(", ")}."
         }
         require(config.iterationTime != null) {
-            "If iterationTimeUnit is provided, iterationTime must also be provided."
+            "Missing iterationTime. Please provide the iterationTime when iterationTimeUnit is given."
         }
     }
     
-
     config.mode?.let {
-        require(it.toLowerCase() in setOf("thrpt", "avgt")) {
-            "Benchmark mode '$it' is not supported."
+        val validModes = setOf("thrpt", "avgt")
+        require(it.toLowerCase() in validModes) {
+            "Unsupported benchmark mode '$it'. Valid modes: ${validModes.joinToString(", ")}."
         }
     }
-
+    
     config.outputTimeUnit?.let {
-        require(it.toLowerCase() in setOf(
-            "seconds", "s", "microseconds", "us", "milliseconds", "ms",
-            "nanoseconds", "ns", "minutes", "m"
-        )) {
-            "Unknown time unit: $it"
+        val validTimeUnits = setOf("seconds", "s", "microseconds", "us", "milliseconds", "ms", "nanoseconds", "ns", "minutes", "m")
+        require(it.toLowerCase() in validTimeUnits) {
+            "Invalid outputTimeUnit '$it'. Valid units: ${validTimeUnits.joinToString(", ")}."
         }
-    }
+    }    
 
     config.includes.forEach {
         require(it.isNotBlank()) {
-            "Include pattern should not be blank."
+            "Include pattern must not be blank."
         }
     }
 
     config.excludes.forEach {
         require(it.isNotBlank()) {
-            "Exclude pattern should not be blank."
+            "Exclude pattern must not be blank."
         }
     }
 
     config.params.forEach { (param, values) ->
         require(param.isNotBlank()) {
-            "Param name should not be blank."
+            "Param name must not be blank."
         }
         require(values.isNotEmpty()) {
-            "Param '$param' should have at least one value."
+            "No values provided for param '$param'. At least one value is required."
         }
     }
 
     config.advanced.forEach { (param, value) ->
         println("Validating advanced param: $param with value: $value")
         require(param.isNotBlank()) {
-            "Advanced config name should not be blank."
+            "Invalid param '$param'. Advanced config name should not be blank."
         }
         require(value.toString().isNotBlank()) {
-            "Value for advanced config '$param' should not be blank."
+            "Invalid value '$value' for param '$param'. Advanced config value should not be blank."
         }
-
+    
         when (param) {
             "nativeFork" -> require(value.toString().toLowerCase() in setOf("perbenchmark", "periteration")) {
-                "Invalid value '$value' for 'nativeFork'. It should be either 'perBenchmark' or 'perIteration'."
+                "Invalid value '$value' for 'nativeFork'. Acceptable values are 'perBenchmark' or 'perIteration'."
             }
             "nativeGCAfterIteration" -> require(value is Boolean) {
-                "Invalid value '$value' for 'nativeGCAfterIteration'. It should be a Boolean value."
+                "Invalid value '$value' for 'nativeGCAfterIteration'. Expecting a Boolean value."
             }
             "jvmForks" -> {
                 val intValue = value.toString().toIntOrNull()
                 require(intValue != null && intValue >= 0 || value.toString().toLowerCase() == "definedbyjmh") {
-                    "Invalid value '$value' for 'jvmForks'. It should be a non-negative integer, or 'definedByJmh'."
+                    "Invalid value '$value' for 'jvmForks'. Acceptable values are a non-negative integer, or 'definedByJmh'."
                 }
             }
             "jsUseBridge" -> require(value is Boolean) {
-                "Invalid value '$value' for 'jsUseBridge'. It should be a Boolean value."
+                "Invalid value '$value' for 'jsUseBridge'. Expecting a Boolean value."
             }
-            else -> throw IllegalArgumentException("Invalid advanced config parameter '$param'. Allowed parameters are 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', and 'jsUseBridge'.")
+            else -> throw IllegalArgumentException("Invalid advanced config parameter '$param'. Valid parameters include 'nativeFork', 'nativeGCAfterIteration', 'jvmForks', and 'jsUseBridge'.")
         }
     }
+    
 }
 
 internal val Gradle.isConfigurationCacheAvailable


### PR DESCRIPTION
This PR aims to centralize the validation of all configuration values in the plugin and introducer a failure if iterationTime or iterationTimeUnit is provided without one another, as per issue #124, #125. 
