### PR TITLE
Remove the kotlin.mpp.enableGranularSourceSetsMetadata from gradle.pr…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@ jmhVersion=1.21
 infra_version=0.3.0-dev-73
 kotlin.code.style=official
 kotlin.incremental.multiplatform=true
-kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.distribution.type=prebuilt
 
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
…operties

This property is set to true since Kotlin ~1.6, so it is already enabled. But in 1.9.20 usage of this property is an error