### PR TITLE
Introduce ValidOptions object to OptionsValidationTest

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -16,7 +16,7 @@ class OptionsValidationTest : GradleTest() {
         }
 
         runner.runAndFail("invalidReportFormatBenchmark") {
-            assertOutputContains("Invalid report format: 'htmll'. Accepted formats: json, csv, scsv, text (e.g., reportFormat = \"json\").")
+            assertOutputContains("Invalid report format: 'htmll'. Accepted formats: ${ValidOptions.format.joinToString(", ")} (e.g., reportFormat = \"json\").")
         }
     }
 
@@ -66,12 +66,6 @@ class OptionsValidationTest : GradleTest() {
         }
     }
 
-    private val validTimeUnits = "NANOSECONDS, ns, nanos, " +
-            "MICROSECONDS, us, micros, " +
-            "MILLISECONDS, ms, millis, " +
-            "SECONDS, s, sec, " +
-            "MINUTES, m, min"
-
     @Test
     fun testIterationTimeUnitValidation() {
         val runner = project("kotlin-multiplatform") {
@@ -88,23 +82,24 @@ class OptionsValidationTest : GradleTest() {
         }
 
         runner.runAndFail("invalidIterationTimeUnitBenchmark") {
-            assertOutputContains("Invalid iterationTimeUnit: 'x'. Accepted units: $validTimeUnits (e.g., iterationTimeUnit = \"ms\").")
+            assertOutputContains("Invalid iterationTimeUnit: 'x'. Accepted units: ${ValidOptions.timeUnits.joinToString(", ")} (e.g., iterationTimeUnit = \"ms\").")
         }
         runner.runAndFail("incorrectCaseIterationTimeUnitBenchmark") {
-            assertOutputContains("Invalid iterationTimeUnit: 'seconds'. Accepted units: $validTimeUnits (e.g., iterationTimeUnit = \"ms\").")
+            assertOutputContains("Invalid iterationTimeUnit: 'seconds'. Accepted units: ${ValidOptions.timeUnits.joinToString(", ")} (e.g., iterationTimeUnit = \"ms\").")
         }
     }
 
     @Test
-    fun testValidIterationTimeUnit() {
+    fun testValidOptions() {
         val runner = project("kotlin-multiplatform") {
-            configuration("validIterationTimeUnit") {
+            configuration("validOptions") {
                 iterations = 1
                 iterationTime = 1
                 iterationTimeUnit = "SECONDS"
+                mode = "AverageTime"
             }
         }
-        runner.run("validIterationTimeUnitBenchmark") // Successful
+        runner.run("validOptionsBenchmark")
     }
 
     @Test
@@ -119,7 +114,7 @@ class OptionsValidationTest : GradleTest() {
         }
 
         runner.runAndFail("invalidModeBenchmark") {
-            assertOutputContains("Invalid benchmark mode: 'x'. Accepted modes: thrpt, avgt (e.g., mode = \"thrpt\").")
+            assertOutputContains("Invalid benchmark mode: 'x'. Accepted modes: ${ValidOptions.modes.joinToString(", ")} (e.g., mode = \"thrpt\").")
         }
     }
 
@@ -135,7 +130,7 @@ class OptionsValidationTest : GradleTest() {
         }
 
         runner.runAndFail("invalidOutputTimeUnitBenchmark") {
-            assertOutputContains("Invalid outputTimeUnit: 'x'. Accepted units: $validTimeUnits (e.g., outputTimeUnit = \"ns\").")
+            assertOutputContains("Invalid outputTimeUnit: 'x'. Accepted units: ${ValidOptions.timeUnits.joinToString(", ")} (e.g., outputTimeUnit = \"ns\").")
         }
     }
 
@@ -240,7 +235,7 @@ class OptionsValidationTest : GradleTest() {
             assertOutputContains("Invalid advanced option name: 'jsFork'. Accepted options: \"nativeFork\", \"nativeGCAfterIteration\", \"jvmForks\", \"jsUseBridge\".")
         }
         runner.runAndFail("invalidNativeForkBenchmark") {
-            assertOutputContains("Invalid value for 'nativeFork': 'x'. Accepted values: perBenchmark, perIteration.")
+            assertOutputContains("Invalid value for 'nativeFork': 'x'. Accepted values: ${ValidOptions.nativeForks.joinToString(", ")}.")
         }
         runner.runAndFail("invalidNativeGCAfterIterationBenchmark") {
             assertOutputContains("Invalid value for 'nativeGCAfterIteration': 'x'. Expected a Boolean value.")
@@ -252,4 +247,17 @@ class OptionsValidationTest : GradleTest() {
             assertOutputContains("Invalid value for 'jsUseBridge': 'x'. Expected a Boolean value.")
         }
     }
+}
+
+private object ValidOptions {
+    val format = setOf("json", "csv", "scsv", "text")
+    val timeUnits = setOf(
+        "NANOSECONDS", "ns", "nanos",
+        "MICROSECONDS", "us", "micros",
+        "MILLISECONDS", "ms", "millis",
+        "SECONDS", "s", "sec",
+        "MINUTES", "m", "min"
+    )
+    val modes = setOf("thrpt", "avgt", "Throughput", "AverageTime")
+    val nativeForks = setOf("perBenchmark", "perIteration")
 }


### PR DESCRIPTION
Introduce the `ValidOptions` object in `OptionsValidationTest` ensuring the integration tests align with the validations. Fixes failing Mode test.