### PR TITLE
Better support for JMH Profiler Configuration

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/JvmProfilerTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/JvmProfilerTest.kt
@@ -1,0 +1,74 @@
+package kotlinx.benchmark.integration
+
+import kotlin.test.*
+
+class JvmProfilerTest : GradleTest() {
+
+    @Test
+    fun testGcProfiler() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("gcProfiler") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jvmProfiler", "gc")
+            }
+        }
+
+        runner.run("jvmGcProfilerBenchmark") {
+            assertOutputContains("gc.alloc.rate")
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testStackProfilerEffect() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("stackProfiler") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jvmProfiler", "stack")
+            }
+        }
+
+        runner.run("jvmStackProfilerBenchmark") {
+            assertOutputContains("stack")
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testClProfiler() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("clProfiler") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jvmProfiler", "cl")
+            }
+        }
+
+        runner.run("jvmClProfilerBenchmark") {
+            assertOutputContains("class.unload.norm")
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testCompProfilerEffect() {
+        val runner = project("kotlin-multiplatform") {
+            configuration("compProfiler") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jvmProfiler", "comp")
+            }
+        }
+
+        runner.run("jvmCompProfilerBenchmark") {
+            assertOutputContains("compiler.time.profiled")
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+}

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -227,7 +227,7 @@ class OptionsValidationTest : GradleTest() {
                 advanced("jsUseBridge", "x")
             }
 
-            configuration("invalidjvmProfiler") {
+            configuration("invalidJvmProfiler") {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
@@ -253,7 +253,7 @@ class OptionsValidationTest : GradleTest() {
         runner.runAndFail("invalidJsUseBridgeBenchmark") {
             assertOutputContains("Invalid value for 'jsUseBridge': 'x'. Expected a Boolean value.")
         }
-        runner.runAndFail("invalidjvmProfiler") {
+        runner.runAndFail("invalidJvmProfiler") {
             assertOutputContains("Invalid value for 'jvmProfiler': 'x'. Accepted values: ${ValidOptions.jvmProfilers.joinToString(", ")}.")
         }
     }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -226,6 +226,13 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
                 advanced("jsUseBridge", "x")
             }
+
+            configuration("invalidjvmProfiler") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jvmProfiler", "x")
+            }
         }
 
         runner.runAndFail("blankAdvancedConfigNameBenchmark") {
@@ -246,6 +253,9 @@ class OptionsValidationTest : GradleTest() {
         runner.runAndFail("invalidJsUseBridgeBenchmark") {
             assertOutputContains("Invalid value for 'jsUseBridge': 'x'. Expected a Boolean value.")
         }
+        runner.runAndFail("invalidjvmProfiler") {
+            assertOutputContains("Invalid value for 'jvmProfiler': 'x'. Accepted values: ${ValidOptions.jvmProfilers.joinToString(", ")}.")
+        }
     }
 }
 
@@ -260,4 +270,5 @@ private object ValidOptions {
     )
     val modes = setOf("thrpt", "avgt", "Throughput", "AverageTime")
     val nativeForks = setOf("perBenchmark", "perIteration")
+    val jvmProfilers = setOf("stack", "gc", "cl", "comp")
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -270,5 +270,5 @@ private object ValidOptions {
     )
     val modes = setOf("thrpt", "avgt", "Throughput", "AverageTime")
     val nativeForks = setOf("perBenchmark", "perIteration")
-    val jvmProfilers = setOf("stack", "gc", "cl", "comp")
+    val jvmProfilers = setOf("stack", "gc", "cl", "comp", "perf", "perfnorm", "perfasm", "xperfasm", " dtraceasm")
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -228,6 +228,11 @@ private fun validateConfig(config: BenchmarkConfiguration) {
             "jsUseBridge" -> require(value is Boolean) {
                 "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
             }
+            "jmhProfiler" -> {
+                require(value.toString() in ValidOptions.jmhProfilers) {
+                    "Invalid value for 'jmhProfiler': '$value'. Accepted values: ${ValidOptions.jmhProfilers.joinToString(", ")}."
+                }
+            }
             else -> throw IllegalArgumentException("Invalid advanced option name: '$param'. Accepted options: \"nativeFork\", \"nativeGCAfterIteration\", \"jvmForks\", \"jsUseBridge\".")
         }
     }
@@ -244,6 +249,7 @@ private object ValidOptions {
     )
     val modes = setOf("thrpt", "avgt", "Throughput", "AverageTime")
     val nativeForks = setOf("perBenchmark", "perIteration")
+    val jmhProfilers = setOf("stack", "gc")
 }
 
 internal val Gradle.isConfigurationCacheAvailable

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -249,7 +249,7 @@ private object ValidOptions {
     )
     val modes = setOf("thrpt", "avgt", "Throughput", "AverageTime")
     val nativeForks = setOf("perBenchmark", "perIteration")
-    val jvmProfilers = setOf("stack", "gc", "cl", "comp")
+    val jvmProfilers = setOf("stack", "gc", "cl", "comp", "perf", "perfnorm", "perfasm", "xperfasm", " dtraceasm")
 }
 
 internal val Gradle.isConfigurationCacheAvailable

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -228,9 +228,9 @@ private fun validateConfig(config: BenchmarkConfiguration) {
             "jsUseBridge" -> require(value is Boolean) {
                 "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
             }
-            "jmhProfiler" -> {
-                require(value.toString() in ValidOptions.jmhProfilers) {
-                    "Invalid value for 'jmhProfiler': '$value'. Accepted values: ${ValidOptions.jmhProfilers.joinToString(", ")}."
+            "jvmProfiler" -> {
+                require(value.toString() in ValidOptions.jvmProfilers) {
+                    "Invalid value for 'jvmProfiler': '$value'. Accepted values: ${ValidOptions.jvmProfilers.joinToString(", ")}."
                 }
             }
             else -> throw IllegalArgumentException("Invalid advanced option name: '$param'. Accepted options: \"nativeFork\", \"nativeGCAfterIteration\", \"jvmForks\", \"jsUseBridge\".")
@@ -249,7 +249,7 @@ private object ValidOptions {
     )
     val modes = setOf("thrpt", "avgt", "Throughput", "AverageTime")
     val nativeForks = setOf("perBenchmark", "perIteration")
-    val jmhProfilers = setOf("stack", "gc")
+    val jvmProfilers = setOf("stack", "gc", "cl", "comp")
 }
 
 internal val Gradle.isConfigurationCacheAvailable

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -233,7 +233,7 @@ private fun validateConfig(config: BenchmarkConfiguration) {
                     "Invalid value for 'jvmProfiler': '$value'. Accepted values: ${ValidOptions.jvmProfilers.joinToString(", ")}."
                 }
             }
-            else -> throw IllegalArgumentException("Invalid advanced option name: '$param'. Accepted options: \"nativeFork\", \"nativeGCAfterIteration\", \"jvmForks\", \"jsUseBridge\".")
+            else -> throw IllegalArgumentException("Invalid advanced option name: '$param'. Accepted options: \"nativeFork\", \"nativeGCAfterIteration\", \"jvmForks\", \"jsUseBridge\", \"jvmProfiler\".")
         }
     }
 }

--- a/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
+++ b/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
@@ -56,6 +56,13 @@ fun main(args: Array<String>) {
         }
     }
 
+    val profilerName = config.advanced["jmhProfiler"]
+    when (profilerName) {
+        "gc" -> jmhOptions.addProfiler("gc")
+        "stack" -> jmhOptions.addProfiler("stack")
+        else -> throw IllegalArgumentException("Unknown JMH profiler: $profilerName")
+    }
+
     val reportFormat = ResultFormatType.valueOf(config.reportFormat.uppercase())
     val reporter = BenchmarkProgress.create(config.traceFormat)
     val output = JmhOutputFormat(reporter, config.name)

--- a/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
+++ b/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
@@ -62,6 +62,7 @@ fun main(args: Array<String>) {
         "stack" -> jmhOptions.addProfiler("stack")
         "cl" -> jmhOptions.addProfiler("cl")
         "comp" -> jmhOptions.addProfiler("comp")
+        null -> {}
         else -> throw IllegalArgumentException("Invalid value for 'jvmProfiler': $profilerName. Accepted values: gc, stack, cl, comp")
     }
 

--- a/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
+++ b/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
@@ -56,7 +56,7 @@ fun main(args: Array<String>) {
         }
     }
 
-    val profilerName = config.advanced["jmhProfiler"]
+    val profilerName = config.advanced["jvmProfiler"]
     when (profilerName) {
         "gc" -> jmhOptions.addProfiler("gc")
         "stack" -> jmhOptions.addProfiler("stack")

--- a/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
+++ b/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
@@ -62,6 +62,11 @@ fun main(args: Array<String>) {
         "stack" -> jmhOptions.addProfiler("stack")
         "cl" -> jmhOptions.addProfiler("cl")
         "comp" -> jmhOptions.addProfiler("comp")
+        "perf" -> jmhOptions.addProfiler("perf")
+        "perfnorm" -> jmhOptions.addProfiler("perfnorm")
+        "perfasm" -> jmhOptions.addProfiler("perfasm")
+        "xperfasm" -> jmhOptions.addProfiler("xperfasm")
+        "dtraceasm" -> jmhOptions.addProfiler("dtraceasm")
         null -> {}
         else -> throw IllegalArgumentException("Invalid value for 'jvmProfiler': $profilerName. Accepted values: gc, stack, cl, comp")
     }

--- a/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
+++ b/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
@@ -62,7 +62,7 @@ fun main(args: Array<String>) {
         "stack" -> jmhOptions.addProfiler("stack")
         "cl" -> jmhOptions.addProfiler("cl")
         "comp" -> jmhOptions.addProfiler("comp")
-        else -> throw IllegalArgumentException("Invalid value for 'jvmProfiler': $profilerName. Accepted values: gc, stack, cl")
+        else -> throw IllegalArgumentException("Invalid value for 'jvmProfiler': $profilerName. Accepted values: gc, stack, cl, comp")
     }
 
     val reportFormat = ResultFormatType.valueOf(config.reportFormat.uppercase())

--- a/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
+++ b/runtime/jvmMain/src/kotlinx/benchmark/jvm/JvmBenchmarkRunner.kt
@@ -60,7 +60,9 @@ fun main(args: Array<String>) {
     when (profilerName) {
         "gc" -> jmhOptions.addProfiler("gc")
         "stack" -> jmhOptions.addProfiler("stack")
-        else -> throw IllegalArgumentException("Unknown JMH profiler: $profilerName")
+        "cl" -> jmhOptions.addProfiler("cl")
+        "comp" -> jmhOptions.addProfiler("comp")
+        else -> throw IllegalArgumentException("Invalid value for 'jvmProfiler': $profilerName. Accepted values: gc, stack, cl")
     }
 
     val reportFormat = ResultFormatType.valueOf(config.reportFormat.uppercase())


### PR DESCRIPTION
 Introduces the capability for users to specify the desired JMH profiler directly as an advanced config option.

`advanced("jmhProfiler", "gc")`

Resolves: #50