### PR TITLE
Annotation usage tests and error msg improvements

### DIFF
--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/AnnotationsSpecifier.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/AnnotationsSpecifier.kt
@@ -1,10 +1,21 @@
 package kotlinx.benchmark.integration
 
 class AnnotationsSpecifier {
+
     private var isMeasurementSpecified: Boolean = false
+    private var isOutputTimeUnitSpecified: Boolean = false
+    private var isBenchmarkModeSpecified: Boolean = false
     private var iterations: Int? = null
     private var time: Int? = null
     private var timeUnit: String? = null
+    private var outputTimeUnit: String? = null
+    private var benchmarkMode: String? = null
+
+    private var fieldName: String = ""
+    private val fieldAnnotations = mutableListOf<String>()
+
+    private var methodName: String = ""
+    private val methodAnnotations = mutableListOf<String>()
 
     fun measurement(iterations: Int, time: Int, timeUnit: String) {
         isMeasurementSpecified = true
@@ -13,14 +24,75 @@ class AnnotationsSpecifier {
         this.timeUnit = timeUnit
     }
 
+    fun outputTimeUnit(timeUnit: String) {
+        isOutputTimeUnitSpecified = true
+        this.outputTimeUnit = timeUnit
+    }
+
+    fun benchmarkMode(mode: String) {
+        isBenchmarkModeSpecified = true
+        this.benchmarkMode = mode
+    }
+
+    fun benchmark(methodName: String) {
+        this.methodName = methodName
+        methodAnnotations.add("@Benchmark")
+    }
+
+    fun setup(methodName: String) {
+        this.methodName = methodName
+        methodAnnotations.add("@Setup")
+    }
+
+    fun teardown(methodName: String) {
+        this.methodName = methodName
+        methodAnnotations.add("@TearDown")
+    }
+
+    fun param(fieldName: String, vararg values: String) {
+        this.fieldName = fieldName
+        fieldAnnotations.add("@Param(${values.joinToString(", ") { "\"$it\"" }})")
+    }
+
+    fun getAnnotationsForField(line: String): String? {
+        val visibilityModifiers = listOf("public", "private", "protected", "internal", "")
+        val matchers = visibilityModifiers.map { modifier ->
+            if (modifier.isEmpty()) {
+                "var $fieldName " to "val $fieldName"
+            } else {
+                "$modifier var $fieldName " to "$modifier val $fieldName"
+            }
+        }
+    
+        if (matchers.any { (varMatcher, valMatcher) ->
+                line.trimStart().startsWith(varMatcher) || line.trimStart().startsWith(valMatcher)
+            }) {
+            return fieldAnnotations.joinToString("\n")
+        }
+        return null
+    }
+    
+    fun getAnnotationsForMethod(line: String): String? {
+        val visibilityModifiers = listOf("public", "private", "protected", "internal", "")
+        val matchers = visibilityModifiers.map { "fun $methodName(" }
+    
+        if (matchers.any { line.contains(it) }) {
+            return methodAnnotations.joinToString("\n")
+        }
+        return null
+    }
+
     fun replacementForLine(line: String): String {
         val trimmedLine = line.trimStart()
         val prefix = line.substring(0, line.length - trimmedLine.length)
         return when {
             isMeasurementSpecified && trimmedLine.startsWith("@Measurement") ->
                 "$prefix@Measurement($iterations, $time, $timeUnit)"
-            else ->
-                line
+            isOutputTimeUnitSpecified && trimmedLine.startsWith("@OutputTimeUnit") ->
+                "$prefix@OutputTimeUnit($outputTimeUnit)"
+            isBenchmarkModeSpecified && trimmedLine.startsWith("@BenchmarkMode") ->
+                "$prefix@BenchmarkMode($benchmarkMode)"
+            else -> line
         }
     }
 }

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/Runner.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/Runner.kt
@@ -41,6 +41,25 @@ class Runner(
         file.writeText(updatedLines.joinToString(separator = "\n"))
     }
 
+    fun addAnnotation(filePath: String, annotationsSpecifier: AnnotationsSpecifier.() -> Unit) {
+        val annotations = AnnotationsSpecifier().also(annotationsSpecifier)
+        val file = projectDir.resolve(filePath)
+
+        val updatedLines = mutableListOf<String>()
+
+        file.readLines().forEach { line ->
+            annotations.getAnnotationsForMethod(line)?.let { annotations ->
+                updatedLines.add(annotations)
+            } ?: annotations.getAnnotationsForField(line)?.let { annotations ->
+                updatedLines.add(annotations)
+            }
+
+            updatedLines.add(line)
+        }
+
+        file.writeText(updatedLines.joinToString(separator = "\n"))
+    }
+
     fun generatedDir(targetName: String, filePath: String, fileTestAction: (File) -> Unit) {
         fileTestAction(
             projectDir.resolve("build/benchmarks/${targetName}/sources/kotlinx/benchmark/generated").resolve(filePath)

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/AnnotationUsageTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/AnnotationUsageTest.kt
@@ -1,0 +1,514 @@
+package kotlinx.benchmark.integration
+
+import kotlin.test.*
+
+class AnnotationUsageTest : GradleTest() {
+    @Test
+    fun testParamWithVal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            param("valProperty", "1", "5")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `valProperty` is read-only (val). Ensure properties annotated with @Param are mutable (var).")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `valProperty` is read-only (val). Ensure properties annotated with @Param are mutable (var).")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `valProperty` is read-only (val). Ensure properties annotated with @Param are mutable (var).")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("@Param annotation is not acceptable on final fields.")
+        }
+    }
+
+    @Test
+    fun testBenchmarkWithFinal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            benchmark("finalMethod")
+        }
+
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testBenchmarkWithPrivate() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            benchmark("privateMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `privateMethod` is private. @Benchmark methods should be public.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `privateMethod` is private. @Benchmark methods should be public.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `privateMethod` is private. @Benchmark methods should be public.")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("@Benchmark method should be public.")
+        }
+    }
+
+    @Test
+    fun testBenchmarkWithInternal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            benchmark("internalMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `internalMethod` is internal.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `internalMethod` is internal.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `internalMethod` is internal.")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testSetupWithPrivate() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            setup("privateMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `privateMethod` is private. @Setup methods should be public.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `privateMethod` is private. @Setup methods should be public.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `privateMethod` is private. @Setup methods should be public.")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("@Setup method should be public.")
+        }
+    }
+
+    @Test
+    fun testTeardownWithPrivate() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            teardown("privateMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `privateMethod` is private. @TearDown methods should be public.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `privateMethod` is private. @TearDown methods should be public.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `privateMethod` is private. @TearDown methods should be public.")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("@TearDown method should be public.")
+        }
+    }
+
+    @Test
+    fun testParamWithPrivate() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            param("privateProperty", "1", "5")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `privateProperty` is private. Ensure properties annotated with @Param are not declared private.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `privateProperty` is private. Ensure properties annotated with @Param are not declared private.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `privateProperty` is private. Ensure properties annotated with @Param are not declared private.")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testParamWithFinal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            param("finalProperty", "1", "5")
+        }
+
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testParamWithInternal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            param("internalProperty", "1", "5")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `internalProperty` is internal. Ensure properties annotated with @Param are not declared internal.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `internalProperty` is internal. Ensure properties annotated with @Param are not declared internal.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Param: Property `internalProperty` is internal. Ensure properties annotated with @Param are not declared internal.")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+    
+    @Test
+    fun testSetupWithFinal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            setup("finalMethod")
+        }
+
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testSetupWithInternal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            setup("internalMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `internalMethod` is internal.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `internalMethod` is internal.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `internalMethod` is internal.")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testTeardownWithProtected() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            teardown("protectedMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `protectedMethod` is protected.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `protectedMethod` is protected.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `protectedMethod` is protected.")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("@TearDown method should be public.")
+        }
+    }
+
+    @Test
+    fun testTeardownWithFinal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            teardown("finalMethod")
+        }
+
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testTeardownWithInternal() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            teardown("internalMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `internalMethod` is internal.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `internalMethod` is internal.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @TearDown: Method `internalMethod` is internal.")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testSetupWithProtected() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            setup("protectedMethod")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `protectedMethod` is protected.")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `protectedMethod` is protected.")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `protectedMethod` is protected.")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("@Setup method should be public.")
+        }
+    }
+
+    @Test
+    fun testBenchmarkAndSetup() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            benchmark("plainMethod")
+            setup("plainMethod")
+        }
+    
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+    
+    @Test
+    fun testBenchmarkAndTearDown() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            benchmark("plainMethod")
+            teardown("plainMethod")
+        }
+    
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testWithSetupAndTearDown() {
+        val runner = project("kotlin-multiplatform")
+        
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            setup("plainMethod")
+            teardown("plainMethod")
+        }
+
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+    
+    @Test
+    fun testBenchmarkWithBlackhole() {
+        val runner = project("kotlin-multiplatform")
+
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            benchmark("blackholeFunction")
+        }
+
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+
+    @Test
+    fun testSetupWithArg() {
+        val runner = project("kotlin-multiplatform")
+    
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            setup("methodWithArg")
+        }
+    
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Setup: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("Method parameters should be either @State classes")
+        }
+    }
+
+    @Test
+    fun testTeardownWithArg() {
+        val runner = project("kotlin-multiplatform")
+
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            teardown("methodWithArg")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Teardown: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Teardown: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Teardown: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("Method parameters should be either @State classes")
+        }
+    }
+    
+    @Test
+    fun testBenchmarkWithArg() {
+        val runner = project("kotlin-multiplatform")
+
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            benchmark("methodWithArg")
+        }
+
+        runner.runAndFail("nativeBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("wasmJsBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("jsIrBenchmark") {
+            assertOutputContains("Invalid usage of @Benchmark: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
+        }
+        runner.runAndFail("jvmBenchmark") {
+            assertOutputContains("Method parameters should be either @State classes")
+        }
+    }
+
+    @Test
+    fun testParamWithMethod() {
+        val runner = project("kotlin-multiplatform")
+
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            param("plainMethod")
+        }
+
+        runner.run("nativeBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("wasmJsBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jsIrBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+        runner.run("jvmBenchmark") {
+            assertOutputContains("BUILD SUCCESSFUL")
+        }
+    }
+}

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/AnnotationUsageTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/AnnotationUsageTest.kt
@@ -3,512 +3,275 @@ package kotlinx.benchmark.integration
 import kotlin.test.*
 
 class AnnotationUsageTest : GradleTest() {
+
+    val platforms = listOf("nativeBenchmark", "wasmJsBenchmark", "jsIrBenchmark")
+
+    private fun executeBenchmark(
+        annotations: List<Pair<String, String>>,
+        error: String = "",
+        jvmSpecificError: String = ""
+    ) {
+        val runner = project("kotlin-multiplatform")
+        configureBenchmarkAnnotations(runner, annotations)
+
+        val hasError = error.isNotEmpty()
+
+        if (hasError) {
+            runBenchmarkWithErrors(runner, error)
+        } else {
+            runBenchmarkSuccessfully(runner)
+        }
+
+        runJvmBenchmark(runner, jvmSpecificError)
+    }
+
+    private fun configureBenchmarkAnnotations(runner: Runner, annotations: List<Pair<String, String>>) {
+        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+            annotations.forEach { (annotation, method) ->
+                when (annotation) {
+                    "benchmark" -> benchmark(method)
+                    "setup" -> setup(method)
+                    "teardown" -> teardown(method)
+                    "param" -> {
+                        val splitMethod = method.split(",")
+                        if (splitMethod.isNotEmpty()) {
+                            val fieldName = splitMethod.first()
+                            val values = splitMethod.drop(1).toTypedArray()
+                            param(fieldName, *values)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun runBenchmarkSuccessfully(runner: Runner) {
+        platforms.forEach { platform ->
+            runner.run(platform) {
+                assertOutputContains("BUILD SUCCESSFUL")
+            }
+        }
+    }
+
+    private fun runBenchmarkWithErrors(runner: Runner, error: String) {
+        platforms.forEach { platform ->
+            runner.runAndFail(platform) {
+                assertOutputContains(error)
+            }
+        }
+    }
+
+    private fun runJvmBenchmark(runner: Runner, jvmSpecificError: String) {
+        if (jvmSpecificError.isNotEmpty()) {
+            runner.runAndFail("jvmBenchmark") {
+                assertOutputContains(jvmSpecificError)
+            }
+        } else {
+            runner.run("jvmBenchmark") {
+                assertOutputContains("BUILD SUCCESSFUL")
+            }
+        }
+    }
+
+
     @Test
     fun testParamWithVal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            param("valProperty", "1", "5")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `valProperty` is read-only (val). Ensure properties annotated with @Param are mutable (var).")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `valProperty` is read-only (val). Ensure properties annotated with @Param are mutable (var).")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `valProperty` is read-only (val). Ensure properties annotated with @Param are mutable (var).")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("@Param annotation is not acceptable on final fields.")
-        }
-    }
-
-    @Test
-    fun testBenchmarkWithFinal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            benchmark("finalMethod")
-        }
-
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testBenchmarkWithPrivate() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            benchmark("privateMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `privateMethod` is private. @Benchmark methods should be public.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `privateMethod` is private. @Benchmark methods should be public.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `privateMethod` is private. @Benchmark methods should be public.")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("@Benchmark method should be public.")
-        }
-    }
-
-    @Test
-    fun testBenchmarkWithInternal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            benchmark("internalMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `internalMethod` is internal.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `internalMethod` is internal.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `internalMethod` is internal.")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testSetupWithPrivate() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            setup("privateMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `privateMethod` is private. @Setup methods should be public.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `privateMethod` is private. @Setup methods should be public.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `privateMethod` is private. @Setup methods should be public.")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("@Setup method should be public.")
-        }
-    }
-
-    @Test
-    fun testTeardownWithPrivate() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            teardown("privateMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `privateMethod` is private. @TearDown methods should be public.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `privateMethod` is private. @TearDown methods should be public.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `privateMethod` is private. @TearDown methods should be public.")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("@TearDown method should be public.")
-        }
+        executeBenchmark(
+            annotations = listOf("param" to "valProperty,1,5"),
+            error = "Invalid usage of @Param: Property `valProperty` is read-only (val). Ensure properties annotated with @Param are mutable (var).",
+            jvmSpecificError = "@Param annotation is not acceptable on final fields."
+        )
     }
 
     @Test
     fun testParamWithPrivate() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            param("privateProperty", "1", "5")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `privateProperty` is private. Ensure properties annotated with @Param are not declared private.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `privateProperty` is private. Ensure properties annotated with @Param are not declared private.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `privateProperty` is private. Ensure properties annotated with @Param are not declared private.")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
+        executeBenchmark(
+            annotations = listOf("param" to "privateProperty,1,5"),
+            error = "Invalid usage of @Param: Property `privateProperty` is private. Ensure properties annotated with @Param are not declared private.",
+        )
     }
 
     @Test
     fun testParamWithFinal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            param("finalProperty", "1", "5")
-        }
-
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
+        executeBenchmark(
+            annotations = listOf("param" to "finalProperty,1,5")
+        )
     }
 
     @Test
     fun testParamWithInternal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            param("internalProperty", "1", "5")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `internalProperty` is internal. Ensure properties annotated with @Param are not declared internal.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `internalProperty` is internal. Ensure properties annotated with @Param are not declared internal.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Param: Property `internalProperty` is internal. Ensure properties annotated with @Param are not declared internal.")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-    
-    @Test
-    fun testSetupWithFinal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            setup("finalMethod")
-        }
-
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testSetupWithInternal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            setup("internalMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `internalMethod` is internal.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `internalMethod` is internal.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `internalMethod` is internal.")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testTeardownWithProtected() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            teardown("protectedMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `protectedMethod` is protected.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `protectedMethod` is protected.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `protectedMethod` is protected.")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("@TearDown method should be public.")
-        }
-    }
-
-    @Test
-    fun testTeardownWithFinal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            teardown("finalMethod")
-        }
-
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testTeardownWithInternal() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            teardown("internalMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `internalMethod` is internal.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `internalMethod` is internal.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @TearDown: Method `internalMethod` is internal.")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testSetupWithProtected() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            setup("protectedMethod")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `protectedMethod` is protected.")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `protectedMethod` is protected.")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `protectedMethod` is protected.")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("@Setup method should be public.")
-        }
-    }
-
-    @Test
-    fun testBenchmarkAndSetup() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            benchmark("plainMethod")
-            setup("plainMethod")
-        }
-    
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-    
-    @Test
-    fun testBenchmarkAndTearDown() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            benchmark("plainMethod")
-            teardown("plainMethod")
-        }
-    
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testWithSetupAndTearDown() {
-        val runner = project("kotlin-multiplatform")
-        
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            setup("plainMethod")
-            teardown("plainMethod")
-        }
-
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-    
-    @Test
-    fun testBenchmarkWithBlackhole() {
-        val runner = project("kotlin-multiplatform")
-
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            benchmark("blackholeFunction")
-        }
-
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-    }
-
-    @Test
-    fun testSetupWithArg() {
-        val runner = project("kotlin-multiplatform")
-    
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            setup("methodWithArg")
-        }
-    
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Setup: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("Method parameters should be either @State classes")
-        }
-    }
-
-    @Test
-    fun testTeardownWithArg() {
-        val runner = project("kotlin-multiplatform")
-
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            teardown("methodWithArg")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Teardown: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Teardown: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Teardown: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("Method parameters should be either @State classes")
-        }
-    }
-    
-    @Test
-    fun testBenchmarkWithArg() {
-        val runner = project("kotlin-multiplatform")
-
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            benchmark("methodWithArg")
-        }
-
-        runner.runAndFail("nativeBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("jsIrBenchmark") {
-            assertOutputContains("Invalid usage of @Benchmark: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object")
-        }
-        runner.runAndFail("jvmBenchmark") {
-            assertOutputContains("Method parameters should be either @State classes")
-        }
+        executeBenchmark(
+            annotations = listOf("param" to "internalProperty,1,5"),
+            error = "Invalid usage of @Param: Property `internalProperty` is internal. Ensure properties annotated with @Param are not declared internal.",
+        )
     }
 
     @Test
     fun testParamWithMethod() {
-        val runner = project("kotlin-multiplatform")
+        executeBenchmark(
+            annotations = listOf("param" to "plainMethod")
+        )
+    }
 
-        runner.addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
-            param("plainMethod")
-        }
 
-        runner.run("nativeBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("wasmJsBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jsIrBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
-        runner.run("jvmBenchmark") {
-            assertOutputContains("BUILD SUCCESSFUL")
-        }
+    @Test
+    fun testBenchmarkWithFinalMethod() {
+        executeBenchmark(
+            annotations = listOf("benchmark" to "finalMethod")
+        )
+    }
+
+
+    @Test
+    fun testBenchmarkWithPrivate() {
+        executeBenchmark(
+            annotations = listOf("benchmark" to "privateMethod"),
+            error = "Invalid usage of @Benchmark: Method `privateMethod` is private. @Benchmark methods should be public.",
+            jvmSpecificError = "@Benchmark method should be public."
+        )
+    }
+
+    @Test
+    fun testBenchmarkWithInternal() {
+        executeBenchmark(
+            annotations = listOf("benchmark" to "internalMethod"),
+            error = "Invalid usage of @Benchmark: Method `internalMethod` is internal."
+        )
+    }
+
+
+    @Test
+    fun testSetupWithPrivate() {
+        executeBenchmark(
+            annotations = listOf("setup" to "privateMethod"),
+            error = "Invalid usage of @Setup: Method `privateMethod` is private. @Setup methods should be public.",
+            jvmSpecificError = "@Setup method should be public."
+        )
+    }
+
+    @Test
+    fun testSetupWithFinal() {
+        executeBenchmark(
+            annotations = listOf("setup" to "finalMethod")
+        )
+    }
+
+    @Test
+    fun testSetupWithInternal() {
+        executeBenchmark(
+            annotations = listOf("setup" to "internalMethod"),
+            error = "Invalid usage of @Setup: Method `internalMethod` is internal."
+        )
+    }
+
+
+    @Test
+    fun testSetupWithProtected() {
+        executeBenchmark(
+            annotations = listOf("setup" to "protectedMethod"),
+            error = "Invalid usage of @Setup: Method `protectedMethod` is protected.",
+            jvmSpecificError = "@Setup method should be public."
+        )
+    }
+
+
+    @Test
+    fun testTeardownWithPrivate() {
+        executeBenchmark(
+            annotations = listOf("teardown" to "privateMethod"),
+            error = "Invalid usage of @TearDown: Method `privateMethod` is private. @TearDown methods should be public.",
+            jvmSpecificError = "@TearDown method should be public."
+        )
+    }
+
+
+    @Test
+    fun testTeardownWithProtected() {
+        executeBenchmark(
+            annotations = listOf("teardown" to "protectedMethod"),
+            error = "Invalid usage of @TearDown: Method `protectedMethod` is protected.",
+            jvmSpecificError = "@TearDown method should be public."
+        )
+    }
+
+    @Test
+    fun testTeardownWithFinal() {
+        executeBenchmark(
+            annotations = listOf("teardown" to "finalMethod")
+        )
+    }
+
+    @Test
+    fun testTeardownWithInternal() {
+        executeBenchmark(
+            annotations = listOf("teardown" to "internalMethod"),
+            error = "Invalid usage of @TearDown: Method `internalMethod` is internal."
+        )
+    }
+
+
+    @Test
+    fun testBenchmarkAndSetup() {
+        executeBenchmark(
+            annotations = listOf(
+                "benchmark" to "plainMethod",
+                "setup" to "plainMethod"
+            )
+        )
+    }
+
+
+    @Test
+    fun testBenchmarkAndTearDown() {
+        executeBenchmark(
+            annotations = listOf(
+                "benchmark" to "plainMethod",
+                "teardown" to "plainMethod"
+            )
+        )
+    }
+
+    @Test
+    fun testWithSetupAndTearDown() {
+        executeBenchmark(
+            annotations = listOf(
+                "setup" to "plainMethod",
+                "teardown" to "plainMethod"
+            )
+        )
+    }
+
+    @Test
+    fun testBenchmarkWithBlackhole() {
+        executeBenchmark(
+            annotations = listOf("benchmark" to "blackholeFunction")
+        )
+    }
+
+    @Test
+    fun testSetupWithArg() {
+        executeBenchmark(
+            annotations = listOf("setup" to "methodWithArg"),
+            error = "Invalid usage of @Setup: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object",
+            jvmSpecificError = "Method parameters should be either @State classes"
+        )
+    }
+
+    @Test
+    fun testTeardownWithArg() {
+        executeBenchmark(
+            annotations = listOf("teardown" to "methodWithArg"),
+            error = "Invalid usage of @Teardown: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object",
+            jvmSpecificError = "Method parameters should be either @State classes"
+        )
+    }
+
+    @Test
+    fun testBenchmarkWithArg() {
+        executeBenchmark(
+            annotations = listOf("benchmark" to "methodWithArg"),
+            error = "Invalid usage of @Benchmark: Method `methodWithArg` has a parameter of type `Int` which is neither a Blackhole nor a @State object",
+            jvmSpecificError = "Method parameters should be either @State classes"
+        )
     }
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/SuiteSourceGeneratorTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/SuiteSourceGeneratorTest.kt
@@ -3,21 +3,121 @@ package kotlinx.benchmark.integration
 import kotlin.test.*
 
 class SuiteSourceGeneratorTest : GradleTest() {
+
+    private fun Runner.assertGeneratedDescriptorContains(substring: String) {
+        generatedDir("native", "test/CommonBenchmark_Descriptor.kt") { descriptorFile ->
+            val text = descriptorFile.readText()
+            assertTrue(text.contains(substring), "Substring: <$substring> not found in <$text>")
+        }
+    }
+
+    private fun Runner.assertGeneratedDescriptorContains(pattern: Regex) {
+        generatedDir("native", "test/CommonBenchmark_Descriptor.kt") { descriptorFile ->
+            val text = descriptorFile.readText()
+            assertTrue(text.contains(pattern), "Pattern: <$pattern> not found in <$text>")
+        }
+    }
+
+    private inline fun testSourceGenerator(setupBlock: Runner.() -> Unit, checkBlock: Runner.() -> Unit) {
+        project("kotlin-multiplatform", true).apply {
+            setupBlock()
+            run("nativeBenchmarkGenerate")
+            checkBlock()
+        }
+    }
+
     @Test
     fun measurementAnnotation() {
-        project("kotlin-multiplatform", true).let { runner ->
-            runner.updateAnnotations("src/commonMain/kotlin/CommonBenchmark.kt") {
-                measurement(iterations = 5, time = 200, timeUnit = "BenchmarkTimeUnit.MILLISECONDS")
-            }
-
-            runner.run("nativeBenchmarkGenerate")
-
-            runner.generatedDir("native", "test/CommonBenchmark_Descriptor.kt") { descriptorFile ->
-                val text = descriptorFile.readText()
+        testSourceGenerator(
+            setupBlock = {
+                updateAnnotations("src/commonMain/kotlin/CommonBenchmark.kt") {
+                    measurement(iterations = 5, time = 200, timeUnit = "BenchmarkTimeUnit.MILLISECONDS")
+                }
+            },
+            checkBlock = {
                 val parameters = "iterations = 5, iterationTime = IterationTime\\(200, BenchmarkTimeUnit.MILLISECONDS\\)"
                     .replace(" ", "\\s+").toRegex()
-                assertTrue(text.contains(parameters), "Parameters: <$parameters> not found in <$text>")
+                assertGeneratedDescriptorContains(parameters)
             }
-        }
+        )
+    }
+
+    @Test
+    fun outputTimeUnitAnnotation() {
+        testSourceGenerator(
+            setupBlock = {
+                updateAnnotations("src/commonMain/kotlin/CommonBenchmark.kt") {
+                    outputTimeUnit("BenchmarkTimeUnit.SECONDS")
+                }
+            },
+            checkBlock = {
+                val parameters = "outputTimeUnit = BenchmarkTimeUnit.SECONDS"
+                    .replace(" ", "\\s+").toRegex()
+                assertGeneratedDescriptorContains(parameters)
+            }
+        )
+    }
+
+    @Test
+    fun benchmarkModeAnnotation() {
+        testSourceGenerator(
+            setupBlock = {
+                updateAnnotations("src/commonMain/kotlin/CommonBenchmark.kt") {
+                    benchmarkMode("Mode.AverageTime")
+                }
+            },
+            checkBlock = {
+                val parameters = "mode = Mode.AverageTime"
+                    .replace(" ", "\\s+").toRegex()
+                assertGeneratedDescriptorContains(parameters)
+            }
+        )
+    }
+
+    @Test
+    fun setupAnnotation() {
+        testSourceGenerator(
+            setupBlock = {
+                addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+                    setup("setUpMethod")
+                }
+            },
+            checkBlock = {
+                val expectedFunctionCall = "instance.setUpMethod()"
+                assertGeneratedDescriptorContains(expectedFunctionCall)
+            }
+        )
+    }
+
+    @Test
+    fun teardownAnnotation() {
+        testSourceGenerator(
+            setupBlock = {
+                addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+                    teardown("teardownMethod")
+                }
+            },
+            checkBlock = {
+                val expectedFunctionCall = "instance.teardownMethod()"
+                assertGeneratedDescriptorContains(expectedFunctionCall)
+            }
+        )
+    }
+
+    @Test
+    fun paramFieldAnnotation() {
+        testSourceGenerator(
+            setupBlock = {
+                addAnnotation("src/commonMain/kotlin/CommonBenchmark.kt") {
+                    param("data", "1", "2")
+                }
+            },
+            checkBlock = {
+                val expectedParameterAnnotation = "parameters = listOf(\"data\")"
+                val expectedDefaultParametersAnnotation = "defaultParameters = mapOf(\"data\" to listOf(\"\"\"1\"\"\", \"\"\"2\"\"\"))"
+                assertGeneratedDescriptorContains(expectedParameterAnnotation)
+                assertGeneratedDescriptorContains(expectedDefaultParametersAnnotation)
+            }
+        )
     }
 }

--- a/integration/src/test/resources/templates/kotlin-multiplatform/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,12 +4,65 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
-@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.NANOSECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.NANOSECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {
+
+    var data = 0
+
+    val valProperty: String = "test"
+
+    final var finalProperty = "This property is final"
+
+    private var privateProperty = "This property is private"
+
+    internal var internalProperty = "This property is internal"
+
     @Benchmark
     open fun mathBenchmark(): Double {
         return log(sqrt(3.0) * cos(3.0), 2.0)
+    }
+
+    fun setUpMethod() {
+        // println("Setup!")
+    }
+
+    fun teardownMethod() {
+        // println("Teardown!")
+    }
+
+    private fun privateMethod() {
+        // println("Private method!")
+    }
+
+    internal fun internalMethod() {
+        // println("Internal method!")
+    }
+
+    protected open fun protectedMethod() {
+        // println("Protected method!")
+    }
+
+    final fun finalMethod() {
+        // println("Final method!")
+    }
+
+    fun plainMethod() {
+        // println("Plain method!")
+    }
+
+    fun blackholeFunction(bh: Blackhole) {
+        val result = sqrt(3.0)
+        bh.consume(result)
+    }
+
+    fun stateFunction(state: CommonBenchmark) {
+        val result = sqrt(3.0)
+        state.data = result.toInt()
+    }
+    
+    fun methodWithArg(number: Int): Double {
+        return sqrt(number.toDouble())
     }
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/JmhBytecodeGeneratorWorker.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JmhBytecodeGeneratorWorker.kt
@@ -106,7 +106,7 @@ abstract class JmhBytecodeGeneratorWorker : WorkAction<JmhBytecodeGeneratorWorkP
                 errCount++
                 sb.append("  - ").append(e.toString()).append("\n")
             }
-            throw RuntimeException("Generation of JMH bytecode failed with " + errCount + "errors:\n" + sb)
+            throw RuntimeException("Generation of JMH bytecode failed with " + errCount + " errors:\n" + sb)
         }
     }
 }


### PR DESCRIPTION
Introduces annotation tests and improves error messages to ensure the library behaves as expected across different use cases.
- [x] Verify failure & error message when using `@Param` on `val` properties.
- [x] Verify success/failure & error clarity when using `@Param` on:
  - [x] `final` properties.
  - [x] `private` properties.
  - [x] `internal` properties.
- [x] Verify success/failure & error clarity when using `@Benchmark` on:
  - [x] `final` methods.
  - [x] `private` methods.
  - [x] `internal` methods.
- [x] Test behavior when a setup, teardown, or benchmark method takes:
  - [x] A `Blackhole`.
  - [ ] A `@State` object.
  - [x] An argument that is neither a `Blackhole` nor a `@State` object.
- [x] Test for successful/error behavior when:
  - [x] A method is marked with both `@Benchmark` and `@Setup/@TearDown`.
  - [x] A method is marked with both `@Setup` and `@TearDown`.
