### PR TITLE
Support nodejs() environment for wasmJs

### DIFF
--- a/examples/kotlin-multiplatform/build.gradle
+++ b/examples/kotlin-multiplatform/build.gradle
@@ -20,7 +20,7 @@ kotlin {
         compilations.create("defaultExecutor") { associateWith(compilations.main) }
         compilations.create("builtInExecutor") { associateWith(compilations.main) }
     }
-    wasm('wasmJs') { d8() }
+    wasm('wasmJs') { nodejs() }
 
     // Native targets
     macosX64()
@@ -134,4 +134,15 @@ benchmark {
         register("linuxX64")
         register("mingwX64")
     }
+}
+
+// Node.js with canary v8 that supports recent Wasm GC changes
+rootProject.extensions.findByType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension.class).with {
+    nodeVersion = "21.0.0-v8-canary202309167e82ab1fa2"
+    nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
+}
+
+// Drop this when node js version become stable
+rootProject.tasks.withType(org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask.class).configureEach {
+    args.add("--ignore-engines")
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/InvalidTargetingTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/InvalidTargetingTest.kt
@@ -7,16 +7,14 @@ class InvalidTargetingTest : GradleTest() {
     @Test
     fun testWasmNodeJs() {
         val runner = project("invalid-target/wasm-nodejs", true)
-        runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("kotlinx-benchmark supports only d8() environment for Kotlin/Wasm.")
-        }
+        runner.run("wasmJsBenchmark") // Successful
     }
 
     @Test
     fun testWasmBrowser() {
         val runner = project("invalid-target/wasm-browser", true)
         runner.runAndFail("wasmJsBenchmark") {
-            assertOutputContains("kotlinx-benchmark supports only d8() environment for Kotlin/Wasm.")
+            assertOutputContains("kotlinx-benchmark only supports d8() and nodejs() environments for Kotlin/Wasm.")
         }
     }
 
@@ -24,7 +22,7 @@ class InvalidTargetingTest : GradleTest() {
     fun testJsD8() {
         val runner = project("invalid-target/js-d8", true)
         runner.runAndFail("jsBenchmark") {
-            assertOutputContains("kotlinx-benchmark supports only nodejs() environment for Kotlin/JS.")
+            assertOutputContains("kotlinx-benchmark only supports nodejs() environment for Kotlin/JS.")
         }
     }
 
@@ -40,7 +38,7 @@ class InvalidTargetingTest : GradleTest() {
     fun testJsBrowser() {
         val runner = project("invalid-target/js-browser", true)
         runner.runAndFail("jsBenchmark") {
-            assertOutputContains("kotlinx-benchmark supports only nodejs() environment for Kotlin/JS.")
+            assertOutputContains("kotlinx-benchmark only supports nodejs() environment for Kotlin/JS.")
         }
     }
 }

--- a/integration/src/test/resources/templates/invalid-target/wasm-nodejs/build.gradle
+++ b/integration/src/test/resources/templates/invalid-target/wasm-nodejs/build.gradle
@@ -2,10 +2,29 @@ kotlin {
     wasm("wasmJs") {
         nodejs()
     }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.5.0-SNAPSHOT")
+            }
+        }
+    }
 }
 
 benchmark {
     targets {
         register("wasmJs")
     }
+}
+
+// Node.js with canary v8 that supports recent Wasm GC changes
+rootProject.extensions.findByType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension.class).with {
+    nodeVersion = "21.0.0-v8-canary202309167e82ab1fa2"
+    nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
+}
+
+// Drop this when node js version become stable
+tasks.withType(org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask.class).configureEach {
+    args.add("--ignore-engines")
 }

--- a/integration/src/test/resources/templates/invalid-target/wasm-nodejs/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/invalid-target/wasm-nodejs/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,15 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.math.*
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun mathBenchmark(): Double {
+        return log(sqrt(3.0) * cos(3.0), 2.0)
+    }
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsEngineExecTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsEngineExecTasks.kt
@@ -26,8 +26,11 @@ fun Project.createJsEngineBenchmarkExecTask(
             if (compilationTarget.isD8Configured) {
                 val execTask = createD8Exec(config, target, compilation, taskName)
                 tasks.getByName(config.prefixName(RUN_BENCHMARKS_TASKNAME)).dependsOn(execTask)
+            } else if (compilationTarget.isNodejsConfigured) {
+                val execTask = createNodeJsExec(config, target, compilation, taskName)
+                tasks.getByName(config.prefixName(RUN_BENCHMARKS_TASKNAME)).dependsOn(execTask)
             } else {
-                throw GradleException("kotlinx-benchmark supports only d8() environment for Kotlin/Wasm.")
+                throw GradleException("kotlinx-benchmark only supports d8() and nodejs() environments for Kotlin/Wasm.")
             }
         }
         KotlinPlatformType.js -> {
@@ -35,7 +38,7 @@ fun Project.createJsEngineBenchmarkExecTask(
                 val execTask = createNodeJsExec(config, target, compilation, taskName)
                 tasks.getByName(config.prefixName(RUN_BENCHMARKS_TASKNAME)).dependsOn(execTask)
             } else {
-                throw GradleException("kotlinx-benchmark supports only nodejs() environment for Kotlin/JS.")
+                throw GradleException("kotlinx-benchmark only supports nodejs() environment for Kotlin/JS.")
             }
         }
         else -> {
@@ -62,7 +65,6 @@ private val KotlinJsIrCompilation.isWasmCompilation: Boolean get() =
 
 private fun MutableList<String>.addWasmArguments() {
     add("--experimental-wasm-gc")
-    add("--experimental-wasm-eh")
 }
 
 private fun MutableList<String>.addJsArguments() {

--- a/runtime/jsMain/src/kotlinx/benchmark/js/JsBenchmarkExecutor.kt
+++ b/runtime/jsMain/src/kotlinx/benchmark/js/JsBenchmarkExecutor.kt
@@ -7,7 +7,7 @@ class JsBenchmarkExecutor(name: String, @Suppress("UNUSED_PARAMETER") dummy_args
     SuiteExecutor(name, jsEngineSupport.arguments()[0]) {
 
     init {
-        check(!isD8) { "${JsBenchmarkExecutor::class.simpleName} does not supports d8 engine" }
+        check(!isD8) { "${JsBenchmarkExecutor::class.simpleName} does not support d8 engine" }
     }
 
     private val benchmarkJs: dynamic = require("benchmark")

--- a/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
+++ b/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
@@ -18,7 +18,7 @@ class JsBuiltInExecutor(
         complete: () -> Unit
     ) {
         if (benchmarks.any { it.isAsync }) {
-            error("${JsBuiltInExecutor::class.simpleName} does not supports async functions")
+            error("${JsBuiltInExecutor::class.simpleName} does not support async functions")
         }
         super.run(runnerConfiguration, benchmarks, start, complete)
     }


### PR DESCRIPTION
Followup to https://github.com/Kotlin/kotlinx-benchmark/pull/165