### PR TITLE
Use toolchains for java tasks

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/GradleTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/GradleTest.kt
@@ -26,7 +26,10 @@ abstract class GradleTest {
         val builder = ProjectBuilder().apply(build)
         templates.resolve(name).copyRecursively(rootProjectDir)
         file("build.gradle").modify(builder::build)
-        file("settings.gradle").writeText("") // empty settings file
+        val settingsFile = file("settings.gradle")
+        if (!settingsFile.exists()) {
+            file("settings.gradle").writeText("") // empty settings file
+        }
         return Runner(rootProjectDir, print, gradleVersion)
     }
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/JvmToolchainsTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/JvmToolchainsTest.kt
@@ -1,12 +1,17 @@
 package kotlinx.benchmark.integration
 
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class JvmToolchainsTest : GradleTest() {
     @Test
     fun testJvmToolchainSetup() {
         val runner = project("kmp-with-toolchain", true, GradleTestVersion.v8_0) {
         }
-        runner.run("jvmBenchmark")
+        runner.run("benchmark") {
+            assertEquals(TaskOutcome.SUCCESS, task(":jvmBenchmark")!!.outcome)
+            assertOutputDoesNotContain("<failure>")
+        }
     }
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/JvmToolchainsTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/JvmToolchainsTest.kt
@@ -1,0 +1,12 @@
+package kotlinx.benchmark.integration
+
+import org.junit.Test
+
+class JvmToolchainsTest : GradleTest() {
+    @Test
+    fun testJvmToolchainSetup() {
+        val runner = project("kmp-with-toolchain", true, GradleTestVersion.v8_0) {
+        }
+        runner.run("jvmBenchmark")
+    }
+}

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/testDsl.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/testDsl.kt
@@ -45,4 +45,14 @@ internal fun BuildResult.assertOutputContains(
     }
 }
 
+internal fun BuildResult.assertOutputDoesNotContain(
+    expectedSubString: String,
+    message: String = "Build output contains \"$expectedSubString\""
+) {
+    assert(!output.contains(expectedSubString)) {
+        printBuildOutput()
+        message
+    }
+}
+
 internal fun BuildResult.assertTasksUpToDate(tasks: Collection<String>) = assertTasksUpToDate(*tasks.toTypedArray())

--- a/integration/src/test/resources/templates/kmp-with-toolchain/build.gradle
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/build.gradle
@@ -1,0 +1,25 @@
+kotlin {
+    jvm {
+        compilations.create('benchmark') { associateWith(compilations.main) }
+        jvmToolchain(21)
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.5.0-SNAPSHOT")
+            }
+        }
+        jvmMain {
+        }
+        jvmBenchmark {
+            dependsOn(jvmMain)
+        }
+    }
+}
+
+benchmark {
+    targets {
+        register("jvm")
+    }
+}

--- a/integration/src/test/resources/templates/kmp-with-toolchain/build.gradle
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/build.gradle
@@ -1,6 +1,5 @@
 kotlin {
     jvm {
-        compilations.create('benchmark') { associateWith(compilations.main) }
         jvmToolchain(21)
     }
 
@@ -9,11 +8,6 @@ kotlin {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.5.0-SNAPSHOT")
             }
-        }
-        jvmMain {
-        }
-        jvmBenchmark {
-            dependsOn(jvmMain)
         }
     }
 }

--- a/integration/src/test/resources/templates/kmp-with-toolchain/gradle.properties
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/kmp-with-toolchain/settings.gradle
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/settings.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}

--- a/integration/src/test/resources/templates/kmp-with-toolchain/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,15 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.math.*
+
+// Don't really need to measure anything here, just check that the benchmark works
+@State(Scope.Benchmark)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1, time = 100, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun mathBenchmark() = 3.14
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
@@ -20,6 +20,7 @@ fun Project.createJvmBenchmarkCompileTask(target: JvmBenchmarkTarget, compileCla
         classpath = compileClasspath
         source = fileTree("$benchmarkBuildDir/sources")
         destinationDirectory.set(file("$benchmarkBuildDir/classes"))
+        javaCompiler.set(javaCompilerProvider())
     }
 
     task<Jar>(
@@ -90,6 +91,9 @@ fun Project.createJvmBenchmarkGenerateSourceTask(
         inputClassesDirs = compilationOutput
         outputResourcesDir = file("$benchmarkBuildDir/resources")
         outputSourcesDir = file("$benchmarkBuildDir/sources")
+        executableProvider = javaLauncherProvider().map {
+            it.executablePath.asFile.absolutePath
+        }
     }
 }
 
@@ -123,5 +127,6 @@ fun Project.createJvmBenchmarkExecTask(
 
         val reportFile = setupReporting(target, config)
         args(writeParameters(target.name, reportFile, traceFormat(), config))
+        javaLauncher.set(javaLauncherProvider())
     }
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -5,7 +5,12 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.invocation.Gradle
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.toolchain.JavaCompiler
+import org.gradle.jvm.toolchain.JavaLauncher
+import org.gradle.jvm.toolchain.JavaToolchainService
 import java.io.File
 import java.nio.file.Path
 import java.time.LocalDateTime
@@ -261,4 +266,16 @@ internal fun Project.getSystemProperty(key: String): String? {
     } else {
         System.getProperty(key)
     }
+}
+
+fun Project.javaCompilerProvider(): Provider<JavaCompiler> = provider {
+    val toolchainService = extensions.findByType(JavaToolchainService::class.java) ?: return@provider null
+    val javaExtension = extensions.findByType(JavaPluginExtension::class.java) ?: return@provider null
+    toolchainService.compilerFor(javaExtension.toolchain).orNull
+}
+
+fun Project.javaLauncherProvider(): Provider<JavaLauncher> = provider {
+    val toolchainService = extensions.findByType(JavaToolchainService::class.java) ?: return@provider null
+    val javaExtension = extensions.findByType(JavaPluginExtension::class.java) ?: return@provider null
+    toolchainService.launcherFor(javaExtension.toolchain).orNull
 }


### PR DESCRIPTION
Gradle tasks configured to run JVM benchmarks didn't use the project's Java toolchain and instead used the same Java executables as the Gradle did. That could lead to a scenario when the project had a Java toolchain with a higher version than the version of Java Gradle was launched with. In such a scenario benchmark compilation would fail.

This PR brings toolchain awareness to related Gradle tasks.

Fixes #176 