### PR TITLE
remove MaxPermSize from gradle.properties in test templates

### DIFF
--- a/integration/src/test/resources/templates/kmp-with-toolchain/gradle.properties
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/kotlin-multiplatform/gradle.properties
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
The option MaxPermSize option triggers an error on my machine:


```text
Caused by: org.gradle.api.GradleException: Unable to start the daemon process.
This problem might be caused by incorrect configuration of the daemon.
For example, an unrecognized jvm option is used.
Please refer to the User Manual chapter on the daemon at https://docs.gradle.org/8.0.2/userguide/gradle_daemon.html
...
Please read the following process output to find out more:
-----------------------
Unrecognized VM option 'MaxPermSize=2048m'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```