### PR TITLE
Configure jvmToolchain in the `kotlin` extension scope

### DIFF
--- a/integration/src/test/resources/templates/kmp-with-toolchain/build.gradle
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/build.gradle
@@ -1,7 +1,6 @@
 kotlin {
-    jvm {
-        jvmToolchain(21)
-    }
+    jvmToolchain(21)
+    jvm {}
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
Otherwise, the latest Kotlin Gradle Plugin (2.0) fails with: "Configuring JVM toolchain in the Kotlin target level DSL is prohibited. JVM toolchain feature should be configured in the extension scope as it affects all JVM targets (JVM, Android)."

It is necessary to move these changes to `master` branch to simplify the support of `kotlin-community/dev` branch. As well as simplifying the future migration of the project to a new version of the compiler.