### PR TITLE
Add settings.gradle.kts into buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,10 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.*
-import java.util.*
-
 plugins {
     `kotlin-dsl`
-}
-
-repositories {
-    mavenCentral()
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,16 @@
+rootProject.name = "buildSrc"
+
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
- buildSrc is (basically) an independent Gradle build, and each Gradle build should have a settings.gradle.kts.
- Use centralized repository definitions.

(Note: Maven Central is defined before GPP so that Gradle will search MC first, and MC tends to be more stable.)