### PR TITLE
Use `Classpath` normalization for classpath inputs of `JmhBytecodeGeneratorTask`

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/JmhBytecodeGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JmhBytecodeGeneratorTask.kt
@@ -17,12 +17,11 @@ constructor(
     private val workerExecutor: WorkerExecutor
 ) : DefaultTask() {
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+
+    @Classpath
     lateinit var inputClassesDirs: FileCollection
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var inputCompileClasspath: FileCollection
 
     @OutputDirectory
@@ -31,8 +30,7 @@ constructor(
     @OutputDirectory
     lateinit var outputSourcesDir: File
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var runtimeClasspath: FileCollection
 
     @Optional

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsSourceGeneratorTask.kt
@@ -25,12 +25,10 @@ constructor(
     @Input
     var useBenchmarkJs: Boolean = true
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var inputClassesDirs: FileCollection
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var inputDependencies: FileCollection
 
     @OutputDirectory

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
@@ -21,12 +21,10 @@ constructor(
     @Input
     lateinit var title: String
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var inputClassesDirs: FileCollection
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var inputDependencies: FileCollection
 
     @OutputDirectory

--- a/plugin/main/src/kotlinx/benchmark/gradle/WasmSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/WasmSourceGeneratorTask.kt
@@ -22,12 +22,10 @@ constructor(
     @Input
     lateinit var title: String
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var inputClassesDirs: FileCollection
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Classpath
     lateinit var inputDependencies: FileCollection
 
     @OutputDirectory


### PR DESCRIPTION
`@InputFiles` with `@PathSensitive(PathSensitivity.RELATIVE)` makes it impossible to reuse build cache between builds with different build numbers because a jar name includes build number.

https://youtrack.jetbrains.com/issue/KTI-1801/benchmarksmainBenchmarkGenerate-cant-use-build-cache-from-builds-with-different-build-number