### PR TITLE
Support debug build configuration for K/N

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -59,6 +59,20 @@ The options listed in the following sections allow you to tailor the benchmark e
 | `advanced("nativeFork", "value")`             | Executes iterations within the same process ("perBenchmark") or each iteration in a separate process ("perIteration"). | `"perBenchmark"`, `"perIteration"` | `"perBenchmark"` |
 | `advanced("nativeGCAfterIteration", value)`   | Whether to trigger garbage collection after each iteration.                                                            | `true`, `false`                    | `false`          |
 
+By default, to run benchmarks, the library uses a release type of native binary, which is optimized one and without debug information.
+It is possibly to change the type to debug by setting it during benchmark targets configuration:
+
+```Kotlin
+benchmark {
+    targets {
+        register("native") {
+            this as NativeBenchmarkTarget
+            buildType = NativeBuildType.DEBUG
+        }
+    }
+}
+```
+
 ### Kotlin/JVM
 | Option                                      | Description                                                | Possible Values                        | Default Value  |
 |---------------------------------------------|------------------------------------------------------------|----------------------------------------|----------------|

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinNativeTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinNativeTest.kt
@@ -1,0 +1,17 @@
+package kotlinx.benchmark.integration
+
+import org.junit.Test
+
+class KotlinNativeTest : GradleTest() {
+    @Test
+    fun debugBenchmarkTest() {
+        project("kotlin-native", true).let { runner ->
+            val target = "native"
+            val capitalizedTarget = target.replaceFirstChar { it.uppercaseChar() }
+
+            runner.run(":${target}BenchmarkGenerate")
+            runner.run(":compile${capitalizedTarget}BenchmarkKotlin${capitalizedTarget}")
+            runner.run(":${capitalizedTarget}Benchmark")
+        }
+    }
+}

--- a/integration/src/test/resources/templates/kotlin-native/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-native/build.gradle
@@ -1,0 +1,27 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.target.HostManager
+
+kotlin {
+    if (HostManager.hostIsLinux) linuxX64('native')
+    if (HostManager.hostIsMingw) mingwX64('native')
+    if (HostManager.host == KonanTarget.MACOS_ARM64.INSTANCE) macosArm64('native')
+    if (HostManager.host == KonanTarget.MACOS_X64.INSTANCE) macosX64('native')
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-benchmark-runtime:0.5.0-SNAPSHOT")
+            }
+        }
+        nativeMain { }
+    }
+}
+
+benchmark {
+    targets {
+        register("native") {
+            buildType = NativeBuildType.DEBUG
+        }
+    }
+}

--- a/integration/src/test/resources/templates/kotlin-native/gradle.properties
+++ b/integration/src/test/resources/templates/kotlin-native/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/kotlin-native/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-native/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,15 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.math.*
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun mathBenchmark(): Double {
+        return log(sqrt(3.0) * cos(3.0), 2.0)
+    }
+}

--- a/integration/src/test/resources/templates/kotlin-native/src/nativeMain/kotlin/DebugBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-native/src/nativeMain/kotlin/DebugBenchmark.kt
@@ -1,0 +1,17 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.native.Platform
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class DebugBenchmark {
+    @Benchmark
+    @OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+    open fun debugBenchmark(): String {
+        return if (Platform.isDebugBinary) "Debug Benchmark"
+        else error("Not a debug binary")
+    }
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
@@ -4,6 +4,7 @@ import kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi
 import org.gradle.api.tasks.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrCompilation
 
 open class BenchmarkConfiguration
@@ -122,4 +123,6 @@ constructor(
     name: String,
     @property:KotlinxBenchmarkPluginInternalApi
     val compilation: KotlinNativeCompilation
-) : BenchmarkTarget(extension, name)
+) : BenchmarkTarget(extension, name) {
+    var buildType: NativeBuildType = NativeBuildType.RELEASE
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -88,7 +88,7 @@ private fun Project.createNativeBenchmarkCompileTask(target: NativeBenchmarkTarg
     compilationTarget.apply {
         binaries {
             // The release build type is already optimized and non-debuggable.
-            executable(benchmarkCompilation.name, listOf(RELEASE)) {
+            executable(benchmarkCompilation.name, listOf(target.buildType)) {
                 this.compilation = benchmarkCompilation
                 this.outputDirectory = file("$benchmarkBuildDir/classes")
                 // A link task's name is linkReleaseExecutable<Target>.
@@ -120,7 +120,7 @@ fun Project.createNativeBenchmarkExecTask(
         description = "Executes benchmark for '${target.name}'"
 
         val binary =
-            benchmarkCompilation.target.binaries.getExecutable(benchmarkCompilation.name, NativeBuildType.RELEASE)
+            benchmarkCompilation.target.binaries.getExecutable(benchmarkCompilation.name, target.buildType)
         val linkTask = binary.linkTask
 
         dependsOn(linkTask)


### PR DESCRIPTION
Adds a build type setting to the NativeBenchmarkTarget to provide the ability to test debug builds. Fixes #189