### PR TITLE
Use Gradle Version Catalog for defining dependencies and versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,14 +9,14 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "kotlinx.team:kotlinx.team.infra:$infra_version"
+        classpath(libs.kotlinx.teamInfraGradlePlugin)
     }
 }
 
 plugins {
     id("base")
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.15.0-Beta.1"
+    alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
 }
 
 apply plugin: 'kotlinx.team.infra'
@@ -55,7 +55,7 @@ afterEvaluate {
 //endregion
 
 allprojects {
-    logger.info("Using Kotlin $kotlin_version for project $it")
+    logger.info("Using Kotlin ${libs.versions.kotlin.get()} for project $it")
     repositories {
         KotlinCommunity.addDevRepositoryIfEnabled(delegate, project)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,6 @@
 group=org.jetbrains.kotlinx
 version=0.5.0-SNAPSHOT
 
-kotlin_version=1.9.21
-jmhVersion=1.21
-infra_version=0.3.0-dev-74
 kotlin.code.style=official
 kotlin.incremental.multiplatform=true
 kotlin.native.distribution.type=prebuilt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,3 +1,38 @@
 [versions]
 
+kotlin = "1.9.21"
+kotlinx-binaryCompatibilityValidator = "0.15.0-Beta.1"
+kotlinx-teamInfra = "0.3.0-dev-74"
+squareup-kotlinpoet = "1.3.0"
+jmh = "1.21"
+gradle-pluginPublish = "0.21.0"
+
 minSupportedGradle = "7.4"
+
+[libraries]
+
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+
+kotlin-utilKlibMetadata = { module = "org.jetbrains.kotlin:kotlin-util-klib-metadata" }
+kotlin-utilKlib = { module = "org.jetbrains.kotlin:kotlin-util-klib" }
+kotlin-utilIo = { module = "org.jetbrains.kotlin:kotlin-util-io" }
+
+kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
+
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
+kotlinx-teamInfraGradlePlugin = { module = "kotlinx.team:kotlinx.team.infra", version.ref = "kotlinx-teamInfra" }
+
+squareup-kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "squareup-kotlinpoet" }
+
+jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
+jmh-generatorBytecode = { module = "org.openjdk.jmh:jmh-generator-bytecode", version.ref = "jmh" }
+
+[plugins]
+
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }
+kotlinx-teamInfraGradlePlugin = { id = "kotlinx.team.infra", version.ref = "kotlinx-teamInfra" }
+
+gradle-pluginPublish = { id = "com.gradle.plugin-publish", version.ref = "gradle-pluginPublish" }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -24,6 +24,6 @@ tasks.test {
     systemProperty("plugin_repo_url", plugin.projectDir.resolve("build/maven").absoluteFile.invariantSeparatorsPath)
     systemProperty("runtime_repo_url", rootProject.buildDir.resolve("maven").absoluteFile.invariantSeparatorsPath)
     systemProperty("kotlin_repo_url", rootProject.properties["kotlin_repo_url"])
-    systemProperty("kotlin_version", rootProject.properties["kotlin_version"]!!)
+    systemProperty("kotlin_version", libs.versions.kotlin.get())
     systemProperty("minSupportedGradleVersion", libs.versions.minSupportedGradle.get())
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -10,20 +10,20 @@ buildscript {
             maven { url = kotlinDevUrl }
         }
     }
+
     dependencies {
-        classpath "kotlinx.team:kotlinx.team.infra:$infra_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath(libs.kotlinx.teamInfraGradlePlugin)
     }
 }
 
 plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '0.21.0'
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.15.0-Beta.2"
+    alias(libs.plugins.gradle.pluginPublish)
+    alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
+    alias(libs.plugins.kotlin.jvm)
 }
 
-apply(plugin: 'org.jetbrains.kotlin.jvm')
 apply(plugin: 'kotlinx.team.infra')
 
 infra {
@@ -37,7 +37,7 @@ infra {
     }
 }
 
-logger.info("Using Kotlin $kotlin_version for project ${project.name}")
+logger.info("Using Kotlin ${libs.versions.kotlin.get()} for project ${project.name}")
 
 repositories {
     mavenCentral()
@@ -90,17 +90,17 @@ tasks.named("compileKotlin", KotlinCompilationTask.class) {
 }
 
 dependencies {
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: kotlin_version
+    implementation(libs.kotlin.reflect)
 
-    implementation 'com.squareup:kotlinpoet:1.3.0'
+    implementation(libs.squareup.kotlinpoet)
 
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-util-klib-metadata', version: kotlin_version
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-util-klib', version: kotlin_version
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-util-io', version: kotlin_version
+    implementation(libs.kotlin.utilKlibMetadata)
+    implementation(libs.kotlin.utilKlib)
+    implementation(libs.kotlin.utilIo)
 
-    compileOnly group: 'org.jetbrains.kotlin.multiplatform', name: 'org.jetbrains.kotlin.multiplatform.gradle.plugin', version: kotlin_version
-    compileOnly "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
-    compileOnly "org.openjdk.jmh:jmh-generator-bytecode:$jmhVersion" // used in worker
+    compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.kotlin.compilerEmbeddable)
+    compileOnly(libs.jmh.generatorBytecode) // used in worker
 }
 
 def generatePluginConstants = tasks.register("generatePluginConstants") {

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,8 +1,4 @@
 group=org.jetbrains.kotlinx
 version=0.5.0-SNAPSHOT
 
-kotlin_version=1.9.21
-jmhVersion=1.21
-infra_version=0.3.0-dev-74
-
 kotlin.code.style=official

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 
 plugins {
-    id 'org.jetbrains.kotlin.multiplatform'
+    alias(libs.plugins.kotlin.multiplatform)
 }
 
 repositories {
@@ -80,12 +80,12 @@ kotlin {
         jvmMain {
             dependsOn(commonMain)
             dependencies {
-                compileOnly "org.openjdk.jmh:jmh-core:$jmhVersion"
+                compileOnly(libs.jmh.core)
             }
         }
         jvmTest {
             dependencies {
-                implementation "org.openjdk.jmh:jmh-core:$jmhVersion"
+                implementation(libs.jmh.core)
             }
         }
         jsMain {


### PR DESCRIPTION
Using a Version Catalog helps with sharing dependencies and aligning versions between different projects.

This is particularly useful because Benchmarks uses Included Builds, and Version Catalogs make it easy to make sure the same dependencies are used in each project.

Notes:

- The version of binary-compatibility-validator was `0.15.0-Beta.1` in the root build, but `0.15.0-Beta.2` in the Benchmark Gradle Plugin build. I had to choose the lower version, because `0.15.0-Beta.2` requires a newer version of Gradle.
- The `kotlinx.team.infra` plugin does not have a published Gradle Plugin Marker, so it has to use the legacy plugin application method (buildscript classpath).