### PR TITLE
Plugin: Remove Kotlin Reflect dependency

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -90,8 +90,6 @@ tasks.named("compileKotlin", KotlinCompilationTask.class) {
 }
 
 dependencies {
-    implementation(libs.kotlin.reflect)
-
     implementation(libs.squareup.kotlinpoet)
 
     implementation(libs.kotlin.utilKlibMetadata)


### PR DESCRIPTION
From what I can tell, the Kotlin Reflect dependency is unnecessary.

To avoid clashes with Gradle's embedded Kotlin, and with other plugins, Gradle plugins should avoid using unnecessary dependencies.