### PR TITLE
Switch expected and actual values in warning for native tasks

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -18,7 +18,7 @@ fun Project.processNativeCompilation(target: NativeBenchmarkTarget) {
     val expectedHost = compilation.target.konanTarget
     val actualHost = HostManager.host
     if (expectedHost != actualHost) {
-        project.logger.warn("Skipping benchmarks for '${target.name}' because they cannot be run on current OS: Expected $expectedHost, but was $actualHost")
+        project.logger.warn("Skipping benchmarks for '${target.name}' because they cannot be run on current host '$actualHost' (expected host: '$expectedHost')")
         return
     }
 

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -15,8 +15,10 @@ import kotlin.io.path.*
 @KotlinxBenchmarkPluginInternalApi
 fun Project.processNativeCompilation(target: NativeBenchmarkTarget) {
     val compilation = target.compilation
-    if (compilation.target.konanTarget != HostManager.host) {
-        project.logger.warn("Skipping benchmarks for '${target.name}' because they cannot be run on current OS: Expected ${compilation.target.konanTarget}, but was ${HostManager.host}")
+    val expectedHost = compilation.target.konanTarget
+    val actualHost = HostManager.host
+    if (expectedHost != actualHost) {
+        project.logger.warn("Skipping benchmarks for '${target.name}' because they cannot be run on current OS: Expected $expectedHost, but was $actualHost")
         return
     }
 

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -16,7 +16,7 @@ import kotlin.io.path.*
 fun Project.processNativeCompilation(target: NativeBenchmarkTarget) {
     val compilation = target.compilation
     if (compilation.target.konanTarget != HostManager.host) {
-        project.logger.warn("Skipping benchmarks for '${target.name}' because they cannot be run on current OS: Expected ${HostManager.host}, but was ${compilation.target.konanTarget}")
+        project.logger.warn("Skipping benchmarks for '${target.name}' because they cannot be run on current OS: Expected ${compilation.target.konanTarget}, but was ${HostManager.host}")
         return
     }
 


### PR DESCRIPTION
Hi,

I was a bit confused with the current warning when the native benchmark is skipped because the current OS does not match the expected for that target
E.g.:
> Skipping benchmarks for 'iosArm64' because they cannot be run on current OS: Expected linux_x64, but was ios_arm64

It sounds more like _target **iosArm64** expects **linux_x64** but the current OS is **ios_arm64**_

If you change the expected and actual values it would be more clear. Please, let me know what you think.

If you disagree feel free to close the PR)