### PR TITLE
Use Worker API for Benchmark generators

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -118,6 +118,9 @@ def generatePluginConstants = tasks.register("generatePluginConstants") {
     Provider<String> minSupportedGradleVersion = libs.versions.minSupportedGradle
     inputs.property("minSupportedGradleVersion", minSupportedGradleVersion)
 
+    Provider<String> kotlinCompilerVersion = libs.versions.kotlin
+    inputs.property("kotlinCompilerVersion", kotlinCompilerVersion)
+
     doLast {
         constantsKtFile.write(
                 """|package kotlinx.benchmark.gradle.internal
@@ -125,6 +128,7 @@ def generatePluginConstants = tasks.register("generatePluginConstants") {
                 |internal object BenchmarksPluginConstants {
                 |  const val BENCHMARK_PLUGIN_VERSION = "${benchmarkPluginVersion.get()}"
                 |  const val MIN_SUPPORTED_GRADLE_VERSION = "${minSupportedGradleVersion.get()}"
+                |  const val DEFAULT_KOTLIN_COMPILER_VERSION = "${kotlinCompilerVersion.get()}"
                 |}
                 |""".stripMargin()
         )

--- a/plugin/main/src/kotlinx/benchmark/gradle/AnnotationsValidator.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/AnnotationsValidator.kt
@@ -1,6 +1,7 @@
 package kotlinx.benchmark.gradle
 
 import kotlinx.benchmark.gradle.SuiteSourceGenerator.Companion.paramAnnotationFQN
+import kotlinx.benchmark.gradle.internal.generator.RequiresKotlinCompilerEmbeddable
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.UnsignedTypes
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -10,6 +11,7 @@ import org.jetbrains.kotlin.js.descriptorUtils.getKotlinTypeFqName
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.annotations.argumentValue
 
+@RequiresKotlinCompilerEmbeddable
 internal fun validateBenchmarkFunctions(functions: List<FunctionDescriptor>) {
     functions.forEach { function ->
         if (function.visibility != DescriptorVisibilities.PUBLIC) {
@@ -30,6 +32,7 @@ internal fun validateBenchmarkFunctions(functions: List<FunctionDescriptor>) {
     }
 }
 
+@RequiresKotlinCompilerEmbeddable
 internal fun validateSetupFunctions(functions: List<FunctionDescriptor>) {
     functions.forEach { function ->
         if (function.visibility != DescriptorVisibilities.PUBLIC) {
@@ -44,6 +47,7 @@ internal fun validateSetupFunctions(functions: List<FunctionDescriptor>) {
     }
 }
 
+@RequiresKotlinCompilerEmbeddable
 internal fun validateTeardownFunctions(functions: List<FunctionDescriptor>) {
     functions.forEach { function ->
         if (function.visibility != DescriptorVisibilities.PUBLIC) {
@@ -58,6 +62,7 @@ internal fun validateTeardownFunctions(functions: List<FunctionDescriptor>) {
     }
 }
 
+@RequiresKotlinCompilerEmbeddable
 internal fun validateParameterProperties(properties: List<PropertyDescriptor>) {
     properties.forEach { property ->
         if (!property.isVar) {

--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksExtension.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksExtension.kt
@@ -4,6 +4,7 @@ import groovy.lang.Closure
 import kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi
 import org.gradle.api.*
 import org.gradle.api.plugins.*
+import org.gradle.api.provider.*
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -16,7 +17,7 @@ fun Project.benchmark(configure: Action<BenchmarksExtension>) {
     extensions.configure(BenchmarksExtension::class.java, configure)
 }
 
-open class BenchmarksExtension
+abstract class BenchmarksExtension
 @KotlinxBenchmarkPluginInternalApi
 constructor(
     val project: Project
@@ -27,6 +28,8 @@ constructor(
     var benchsDescriptionDir: String = "benchsDescription"
 
     val version = BenchmarksPlugin.PLUGIN_VERSION
+
+    abstract val kotlinCompilerVersion: Property<String>
 
     fun configurations(configureClosure: Closure<NamedDomainObjectContainer<BenchmarkConfiguration>>): NamedDomainObjectContainer<BenchmarkConfiguration> {
         return configurations.configure(configureClosure)
@@ -46,7 +49,8 @@ constructor(
 
     val targets: NamedDomainObjectContainer<BenchmarkTarget> = run {
         project.container(BenchmarkTarget::class.java) { name ->
-            val multiplatformClass = tryGetClass<KotlinMultiplatformExtension>("org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension")
+            val multiplatformClass =
+                tryGetClass<KotlinMultiplatformExtension>("org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension")
             val multiplatform = multiplatformClass?.let { project.extensions.findByType(it) }
             val javaExtension = project.extensions.findByType(JavaPluginExtension::class.java)
 

--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksPlugin.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksPlugin.kt
@@ -1,15 +1,22 @@
 package kotlinx.benchmark.gradle
 
+import kotlinx.benchmark.gradle.internal.BenchmarkDependencies
 import kotlinx.benchmark.gradle.internal.BenchmarksPluginConstants
+import kotlinx.benchmark.gradle.internal.BenchmarksPluginConstants.DEFAULT_KOTLIN_COMPILER_VERSION
 import kotlinx.benchmark.gradle.internal.BenchmarksPluginConstants.MIN_SUPPORTED_GRADLE_VERSION
 import kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi
 import org.gradle.api.*
+import org.gradle.api.provider.*
 import org.gradle.util.GradleVersion
+import javax.inject.Inject
 
 @Suppress("unused")
 abstract class BenchmarksPlugin
 @KotlinxBenchmarkPluginInternalApi
-constructor() : Plugin<Project> {
+@Inject
+constructor(
+    private val providers: ProviderFactory,
+) : Plugin<Project> {
 
     companion object {
         const val PLUGIN_ID = "org.jetbrains.kotlinx.benchmark"
@@ -50,7 +57,7 @@ constructor() : Plugin<Project> {
 
     override fun apply(project: Project) = project.run {
         // DO NOT use properties of an extension immediately, it will not contain any user-specified data
-        val extension = extensions.create(BENCHMARK_EXTENSION_NAME, BenchmarksExtension::class.java, project)
+        val extension = createBenchmarksExtension(project)
 
         if (GradleVersion.current() < GradleVersion.version(MIN_SUPPORTED_GRADLE_VERSION)) {
             logger.error("JetBrains Gradle Benchmarks plugin requires Gradle version $MIN_SUPPORTED_GRADLE_VERSION or higher")
@@ -62,19 +69,24 @@ constructor() : Plugin<Project> {
             if (!getKotlinVersion(kotlinPlugin.pluginVersion).isAtLeast(1, 9, 20)) {
                 logger.error("JetBrains Gradle Benchmarks plugin requires Kotlin version 1.9.20 or higher")
             }
+            extension.kotlinCompilerVersion.set(kotlinPlugin.pluginVersion)
         }
 
-        // Create empty task that will depend on all benchmark building tasks to build all benchmarks in a project
+        // Create a lifecycle task that will depend on all benchmark building tasks to build all benchmarks in a project
         val assembleBenchmarks = task<DefaultTask>(ASSEMBLE_BENCHMARKS_TASKNAME) {
             group = BENCHMARKS_TASK_GROUP
             description = "Generate and build all benchmarks in a project"
         }
 
+        val benchmarkDependencies = BenchmarkDependencies(project, extension)
+
+        configureBenchmarkTaskConventions(project, benchmarkDependencies)
+
         // TODO: Design configuration avoidance
         // I currently don't know how to do it correctly yet, so materialize all tasks after project evaluation.
         afterEvaluate {
             extension.configurations.forEach {
-                // Create empty task that will depend on all benchmark execution tasks to run all benchmarks in a project
+                // Create a lifecycle task that will depend on all benchmark execution tasks to run all benchmarks in a project
                 task<DefaultTask>(it.prefixName(RUN_BENCHMARKS_TASKNAME)) {
                     group = BENCHMARKS_TASK_GROUP
                     description = "Execute all benchmarks in a project"
@@ -92,6 +104,12 @@ constructor() : Plugin<Project> {
         }
     }
 
+    private fun createBenchmarksExtension(project: Project): BenchmarksExtension {
+        return project.extensions.create(BENCHMARK_EXTENSION_NAME, BenchmarksExtension::class.java, project).apply {
+            kotlinCompilerVersion.convention(DEFAULT_KOTLIN_COMPILER_VERSION)
+        }
+    }
+
     private fun Project.processConfigurations(extension: BenchmarksExtension) {
         // Calling `all` on NDOC causes all items to materialize and be configured
         extension.targets.all { config ->
@@ -102,6 +120,21 @@ constructor() : Plugin<Project> {
                 is WasmBenchmarkTarget -> processWasmCompilation(config)
                 is NativeBenchmarkTarget -> processNativeCompilation(config)
             }
+        }
+    }
+
+    private fun configureBenchmarkTaskConventions(
+        project: Project,
+        benchmarkDependencies: BenchmarkDependencies,
+    ) {
+        project.tasks.withType(NativeSourceGeneratorTask::class.java).configureEach {
+            it.runtimeClasspath.from(benchmarkDependencies.benchmarkGeneratorResolver)
+        }
+        project.tasks.withType(WasmSourceGeneratorTask::class.java).configureEach {
+            it.runtimeClasspath.from(benchmarkDependencies.benchmarkGeneratorResolver)
+        }
+        project.tasks.withType(JsSourceGeneratorTask::class.java).configureEach {
+            it.runtimeClasspath.from(benchmarkDependencies.benchmarkGeneratorResolver)
         }
     }
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/JmhBytecodeGeneratorWorker.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JmhBytecodeGeneratorWorker.kt
@@ -30,7 +30,8 @@ import java.net.URL
 import java.net.URLClassLoader
 
 @KotlinxBenchmarkPluginInternalApi
-// TODO Make visibility of JmhBytecodeGeneratorWorker `internal` in version 1.0.
+// TODO https://github.com/Kotlin/kotlinx-benchmark/issues/211
+//      Change visibility of JmhBytecodeGeneratorWorker `internal`
 //      Move to package kotlinx.benchmark.gradle.internal.generator.workers, alongside the other workers.
 abstract class JmhBytecodeGeneratorWorker : WorkAction<JmhBytecodeGeneratorWorkParameters> {
 
@@ -126,9 +127,8 @@ abstract class JmhBytecodeGeneratorWorker : WorkAction<JmhBytecodeGeneratorWorkP
 }
 
 @KotlinxBenchmarkPluginInternalApi
-// TODO In version 1.0:
-//     - Make internal
-//     - Move to a nested interface inside of JmhBytecodeGeneratorWorker (like the other workers)
+// TODO https://github.com/Kotlin/kotlinx-benchmark/issues/211
+//      Move to a nested interface inside of JmhBytecodeGeneratorWorker (like the other workers)
 interface JmhBytecodeGeneratorWorkParameters : WorkParameters {
     val inputClasses: ConfigurableFileCollection
     val inputClasspath: ConfigurableFileCollection

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsSourceGeneratorTask.kt
@@ -1,18 +1,17 @@
 package kotlinx.benchmark.gradle
 
 import kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
+import kotlinx.benchmark.gradle.internal.generator.RequiresKotlinCompilerEmbeddable
+import kotlinx.benchmark.gradle.internal.generator.workers.GenerateJsSourceWorker
+import org.gradle.api.*
+import org.gradle.api.file.*
 import org.gradle.api.tasks.*
 import org.gradle.workers.WorkerExecutor
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.storage.LockBasedStorageManager
-import org.jetbrains.kotlin.storage.StorageManager
 import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
-open class JsSourceGeneratorTask
+abstract class JsSourceGeneratorTask
 @KotlinxBenchmarkPluginInternalApi
 @Inject
 constructor(
@@ -37,34 +36,28 @@ constructor(
     @OutputDirectory
     lateinit var outputSourcesDir: File
 
+    @get:Classpath
+    abstract val runtimeClasspath: ConfigurableFileCollection
+
     @TaskAction
     fun generate() {
-        cleanup(outputSourcesDir)
-        cleanup(outputResourcesDir)
-
-        inputClassesDirs.files.forEach { lib: File ->
-            generateSources(lib)
+        val workQueue = workerExecutor.classLoaderIsolation {
+            it.classpath.from(runtimeClasspath)
         }
-    }
 
-    private fun generateSources(lib: File) {
-        val modules = loadIr(lib, LockBasedStorageManager("Inspect"))
-        modules.forEach { module ->
-            val generator = SuiteSourceGenerator(
-                title,
-                module,
-                outputSourcesDir,
-                if (useBenchmarkJs) Platform.JsBenchmarkJs else Platform.JsBuiltIn
-            )
-            generator.generate()
+        @OptIn(RequiresKotlinCompilerEmbeddable::class)
+        workQueue.submit(GenerateJsSourceWorker::class.java) {
+            it.title.set(title)
+            it.inputClasses.from(inputClassesDirs)
+            it.inputDependencies.from(inputDependencies)
+            it.outputSourcesDir.set(outputSourcesDir)
+            it.outputResourcesDir.set(outputResourcesDir)
+            it.useBenchmarkJs.set(useBenchmarkJs)
         }
-    }
 
-    private fun loadIr(lib: File, storageManager: StorageManager): List<ModuleDescriptor> {
-        // skip processing of empty dirs (fails if not to do it)
-        if (lib.listFiles() == null) return emptyList()
-        val dependencies = inputDependencies.files.filterNot { it.extension == "js" }.toSet()
-        val module = KlibResolver.JS.createModuleDescriptor(lib, dependencies, storageManager)
-        return listOf(module)
+        workQueue.await() // I'm not sure if waiting is necessary,
+        // but I suspect that the task dependencies aren't configured correctly,
+        // so: better-safe-than-sorry.
+        // Try removing await() when Benchmarks follows Gradle best practices.
     }
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
@@ -1,22 +1,29 @@
 package kotlinx.benchmark.gradle
 
-import org.jetbrains.kotlin.backend.common.serialization.metadata.*
-import org.jetbrains.kotlin.builtins.*
-import org.jetbrains.kotlin.config.*
-import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.incremental.components.*
-import org.jetbrains.kotlin.konan.library.*
-import org.jetbrains.kotlin.library.*
-import org.jetbrains.kotlin.library.impl.*
-import org.jetbrains.kotlin.library.metadata.*
-import org.jetbrains.kotlin.library.metadata.resolver.impl.*
-import org.jetbrains.kotlin.storage.*
-import org.jetbrains.kotlin.util.*
+import kotlinx.benchmark.gradle.internal.generator.RequiresKotlinCompilerEmbeddable
+import org.jetbrains.kotlin.backend.common.serialization.metadata.DynamicTypeDeserializer
+import org.jetbrains.kotlin.builtins.DefaultBuiltIns
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.incremental.components.LookupTracker
+import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
+import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.KotlinLibraryProperResolverWithAttributes
+import org.jetbrains.kotlin.library.impl.createKotlinLibraryComponents
+import org.jetbrains.kotlin.library.metadata.KlibMetadataFactories
+import org.jetbrains.kotlin.library.metadata.NullFlexibleTypeDeserializer
+import org.jetbrains.kotlin.library.metadata.resolver.impl.KotlinLibraryResolverImpl
+import org.jetbrains.kotlin.library.metadata.resolver.impl.libraryResolver
+import org.jetbrains.kotlin.library.resolveSingleFileKlib
+import org.jetbrains.kotlin.library.unresolvedDependencies
+import org.jetbrains.kotlin.storage.StorageManager
+import org.jetbrains.kotlin.util.Logger
 import java.io.*
 import org.jetbrains.kotlin.konan.file.File as KonanFile
 
 internal enum class KlibResolver { JS, Native }
 
+@RequiresKotlinCompilerEmbeddable
 internal fun KlibResolver.createModuleDescriptor(
     lib: File,
     inputDependencies: Set<File>,
@@ -60,6 +67,7 @@ internal fun KlibResolver.createModuleDescriptor(
     return module
 }
 
+@RequiresKotlinCompilerEmbeddable
 private fun KlibResolver.klibMetadataFactories() = KlibMetadataFactories(
     createBuiltIns = { DefaultBuiltIns.Instance },
     flexibleTypeDeserializer = when (this) {
@@ -68,6 +76,7 @@ private fun KlibResolver.klibMetadataFactories() = KlibMetadataFactories(
     }
 )
 
+@RequiresKotlinCompilerEmbeddable
 private fun KlibResolver.libraryResolver(inputDependencies: Set<File>): KotlinLibraryResolverImpl<KotlinLibrary> {
     val logger = object : Logger {
         override fun log(message: String) {}
@@ -86,6 +95,7 @@ private fun KlibResolver.libraryResolver(inputDependencies: Set<File>): KotlinLi
     ).libraryResolver()
 }
 
+@RequiresKotlinCompilerEmbeddable
 private class KLibLibraryResolver(
     klibs: List<String>,
     knownIrProviders: List<String>,

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
@@ -66,9 +66,9 @@ constructor(
 }
 
 @KotlinxBenchmarkPluginInternalApi
-// TODO In version 1.0:
-//     - Make internal
-//     - Move to a nested interface inside of JmhBytecodeGeneratorWorker (like the other workers)
+// TODO https://github.com/Kotlin/kotlinx-benchmark/issues/211
+//      Replace NativeSourceGeneratorWorkerParameters with NativeSourceGeneratorWorker.Parameters,
+//      so that it is like the other workers.
 interface NativeSourceGeneratorWorkerParameters : WorkParameters {
     var title: String
     var target: String
@@ -80,11 +80,13 @@ interface NativeSourceGeneratorWorkerParameters : WorkParameters {
 
 @KotlinxBenchmarkPluginInternalApi
 @RequiresKotlinCompilerEmbeddable
-// TODO Make visibility of NativeSourceGeneratorWorker `internal` in version 1.0.
+// TODO https://github.com/Kotlin/kotlinx-benchmark/issues/211
+//      Change visibility of NativeSourceGeneratorWorker to `internal`
 //      Move to package kotlinx.benchmark.gradle.internal.generator.workers, alongside the other workers.
 abstract class NativeSourceGeneratorWorker : WorkAction<NativeSourceGeneratorWorkerParameters> {
 
-    // TODO in version 1.0 replace NativeSourceGeneratorWorkerParameters with this interface:
+    // TODO https://github.com/Kotlin/kotlinx-benchmark/issues/211
+    //      replace NativeSourceGeneratorWorkerParameters with this interface:
     //internal interface Parameters : WorkParameters {
     //    val title: Property<String>
     //    val target: Property<String>

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
@@ -1,17 +1,20 @@
 package kotlinx.benchmark.gradle
 
 import kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi
+import kotlinx.benchmark.gradle.internal.generator.RequiresKotlinCompilerEmbeddable
 import org.gradle.api.*
 import org.gradle.api.file.*
 import org.gradle.api.tasks.*
-import org.gradle.workers.*
-import org.jetbrains.kotlin.library.*
-import org.jetbrains.kotlin.storage.*
-import java.io.*
-import javax.inject.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import org.jetbrains.kotlin.library.KLIB_FILE_EXTENSION_WITH_DOT
+import org.jetbrains.kotlin.storage.LockBasedStorageManager
+import java.io.File
+import javax.inject.Inject
 
 @CacheableTask
-open class NativeSourceGeneratorTask
+abstract class NativeSourceGeneratorTask
 @KotlinxBenchmarkPluginInternalApi
 @Inject
 constructor(
@@ -36,22 +39,36 @@ constructor(
     @Input
     lateinit var nativeTarget: String
 
+    @get:Classpath
+    abstract val runtimeClasspath: ConfigurableFileCollection
+
     @TaskAction
     fun generate() {
-        val workQueue = workerExecutor.classLoaderIsolation()
-        workQueue.submit(NativeSourceGeneratorWorker::class.java) { parameters ->
-            parameters.title = title
-            parameters.target = nativeTarget
-            parameters.inputClassesDirs = inputClassesDirs.files
-            parameters.inputDependencies = inputDependencies.files
-            parameters.outputSourcesDir = outputSourcesDir
-            parameters.outputResourcesDir = outputResourcesDir
+        val workQueue = workerExecutor.classLoaderIsolation {
+            it.classpath.from(runtimeClasspath)
         }
-        workQueue.await()
+
+        @OptIn(RequiresKotlinCompilerEmbeddable::class)
+        workQueue.submit(NativeSourceGeneratorWorker::class.java) {
+            it.title = title
+            it.target = nativeTarget
+            it.inputClassesDirs = inputClassesDirs.files
+            it.inputDependencies = inputDependencies.files
+            it.outputSourcesDir = outputSourcesDir
+            it.outputResourcesDir = outputResourcesDir
+        }
+
+        workQueue.await() // I'm not sure if waiting is necessary,
+        // but I suspect that the task dependencies aren't configured correctly,
+        // so: better-safe-than-sorry.
+        // Try removing await() when Benchmarks follows Gradle best practices.
     }
 }
 
 @KotlinxBenchmarkPluginInternalApi
+// TODO In version 1.0:
+//     - Make internal
+//     - Move to a nested interface inside of JmhBytecodeGeneratorWorker (like the other workers)
 interface NativeSourceGeneratorWorkerParameters : WorkParameters {
     var title: String
     var target: String
@@ -62,10 +79,24 @@ interface NativeSourceGeneratorWorkerParameters : WorkParameters {
 }
 
 @KotlinxBenchmarkPluginInternalApi
+@RequiresKotlinCompilerEmbeddable
+// TODO Make visibility of NativeSourceGeneratorWorker `internal` in version 1.0.
+//      Move to package kotlinx.benchmark.gradle.internal.generator.workers, alongside the other workers.
 abstract class NativeSourceGeneratorWorker : WorkAction<NativeSourceGeneratorWorkerParameters> {
+
+    // TODO in version 1.0 replace NativeSourceGeneratorWorkerParameters with this interface:
+    //internal interface Parameters : WorkParameters {
+    //    val title: Property<String>
+    //    val target: Property<String>
+    //    val inputClassesDirs: ConfigurableFileCollection
+    //    val inputDependencies: ConfigurableFileCollection
+    //    val outputSourcesDir: DirectoryProperty
+    //    val outputResourcesDir: DirectoryProperty
+    //}
+
     override fun execute() {
-        cleanup(parameters.outputSourcesDir)
-        cleanup(parameters.outputResourcesDir)
+        parameters.outputSourcesDir.deleteRecursively()
+        parameters.outputResourcesDir.deleteRecursively()
         parameters.inputClassesDirs
             .filter { it.exists() && it.name.endsWith(KLIB_FILE_EXTENSION_WITH_DOT) }
             .forEach { lib ->
@@ -73,7 +104,8 @@ abstract class NativeSourceGeneratorWorker : WorkAction<NativeSourceGeneratorWor
                     throw Exception("nativeTarget should be specified for API generator for native targets")
 
                 val storageManager = LockBasedStorageManager("Inspect")
-                val module = KlibResolver.Native.createModuleDescriptor(lib, parameters.inputDependencies, storageManager)
+                val module =
+                    KlibResolver.Native.createModuleDescriptor(lib, parameters.inputDependencies, storageManager)
                 val generator = SuiteSourceGenerator(
                     parameters.title,
                     module,

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -2,12 +2,10 @@ package kotlinx.benchmark.gradle
 
 import groovy.lang.Closure
 import kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi
-import org.gradle.api.Action
-import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.*
+import org.gradle.api.plugins.*
+import org.gradle.api.provider.*
+import org.gradle.api.tasks.*
 import org.gradle.jvm.toolchain.JavaCompiler
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
@@ -18,16 +16,9 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @KotlinxBenchmarkPluginInternalApi
+@Deprecated("Unused - replace with Kotlin stdlib function", ReplaceWith("file.deleteRecursively()"))
 fun cleanup(file: File) {
-    if (file.exists()) {
-        val listing = file.listFiles()
-        if (listing != null) {
-            for (sub in listing) {
-                cleanup(sub)
-            }
-        }
-        file.delete()
-    }
+    file.deleteRecursively()
 }
 
 @KotlinxBenchmarkPluginInternalApi
@@ -234,21 +225,26 @@ private fun validateConfig(config: BenchmarkConfiguration) {
         when (param) {
             "nativeFork" -> {
                 require(value.toString() in ValidOptions.nativeForks) {
-                    "Invalid value for 'nativeFork': '$value'. Accepted values: ${ValidOptions.nativeForks.joinToString(", ")}."
+                    "Invalid value for 'nativeFork': '$value'. " +
+                            "Accepted values: ${ValidOptions.nativeForks.joinToString(", ")}."
                 }
             }
+
             "nativeGCAfterIteration" -> require(value is Boolean) {
                 "Invalid value for 'nativeGCAfterIteration': '$value'. Expected a Boolean value."
             }
+
             "jvmForks" -> {
                 val intValue = value.toString().toIntOrNull()
                 require(intValue != null && intValue >= 0 || value.toString() == "definedByJmh") {
                     "Invalid value for 'jvmForks': '$value'. Expected a non-negative integer or \"definedByJmh\"."
                 }
             }
+
             "jsUseBridge" -> require(value is Boolean) {
                 "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
             }
+
             else -> throw IllegalArgumentException("Invalid advanced option name: '$param'. Accepted options: \"nativeFork\", \"nativeGCAfterIteration\", \"jvmForks\", \"jsUseBridge\".")
         }
     }

--- a/plugin/main/src/kotlinx/benchmark/gradle/internal/BenchmarkDependencies.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/internal/BenchmarkDependencies.kt
@@ -1,0 +1,79 @@
+package kotlinx.benchmark.gradle.internal
+
+import kotlinx.benchmark.gradle.BenchmarksExtension
+import org.gradle.api.*
+import org.gradle.api.artifacts.*
+import org.gradle.api.attributes.*
+import org.gradle.api.attributes.Usage.*
+import org.gradle.api.model.*
+import org.gradle.util.GradleVersion
+
+/**
+ * Utility for containing all Gradle [Configuration]s used by Benchmarks.
+ */
+internal class BenchmarkDependencies(
+    project: Project,
+    benchmarksExtension: BenchmarksExtension,
+) {
+    private val objects: ObjectFactory = project.objects
+
+    private val benchmarkGenerator: Configuration =
+        project.configurations.create("benchmarkGenerator") {
+            it.description =
+                "Internal Kotlinx Benchmarks Configuration. Contains declared dependencies required for running benchmark generators."
+            it.declarable()
+
+            it.defaultDependencies { deps ->
+                deps.addLater(
+                    benchmarksExtension.kotlinCompilerVersion.map { version ->
+                        project.dependencies.create("org.jetbrains.kotlin:kotlin-compiler-embeddable:$version")
+                    }
+                )
+            }
+        }
+
+    val benchmarkGeneratorResolver: Configuration =
+        project.configurations.create("benchmarkGenerator.resolver") {
+            // The name has a dot, to prevent Gradle from generating a Kotlin DSL accessor.
+            it.description =
+                "Internal Kotlinx Benchmarks Configuration. Resolves dependencies required for running benchmark generators."
+            it.resolvable()
+
+            it.extendsFrom(benchmarkGenerator)
+
+            it.attributes { atts ->
+                atts.attribute(USAGE_ATTRIBUTE, objects.named(Usage::class.java, JAVA_RUNTIME))
+            }
+        }
+
+    internal companion object {
+
+        /** Mark this [Configuration] as one that will be used to declare dependencies. */
+        private fun Configuration.declarable() {
+            isCanBeDeclaredCompat = true
+            isCanBeResolved = false
+            isCanBeConsumed = false
+            isVisible = false
+        }
+
+        /** Mark this [Configuration] as one that will be used to resolve dependencies. */
+        private fun Configuration.resolvable() {
+            isCanBeDeclaredCompat = false
+            isCanBeResolved = true
+            isCanBeConsumed = false
+            isVisible = false
+        }
+
+        @Suppress("UnstableApiUsage")
+        /** `true` if [Configuration.isCanBeDeclared] is supported by the current Gradle version. */
+        private val isCanBeDeclaredSupported = GradleVersion.current() >= GradleVersion.version("8.2")
+
+        // Remove when minimum supported Gradle version is >= 8.2
+        @Suppress("UnstableApiUsage")
+        private var Configuration.isCanBeDeclaredCompat: Boolean
+            get() = if (isCanBeDeclaredSupported) isCanBeDeclared else false
+            set(value) {
+                if (isCanBeDeclaredSupported) isCanBeDeclared = value
+            }
+    }
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/internal/BenchmarkDependencies.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/internal/BenchmarkDependencies.kt
@@ -20,7 +20,7 @@ internal class BenchmarkDependencies(
     private val benchmarkGenerator: Configuration =
         project.configurations.create("benchmarkGenerator") {
             it.description =
-                "Internal Kotlinx Benchmarks Configuration. Contains declared dependencies required for running benchmark generators."
+                "Internal kotlinx-benchmark Configuration. Contains declared dependencies required for running benchmark generators."
             it.declarable()
 
             it.defaultDependencies { deps ->
@@ -36,7 +36,7 @@ internal class BenchmarkDependencies(
         project.configurations.create("benchmarkGenerator.resolver") {
             // The name has a dot, to prevent Gradle from generating a Kotlin DSL accessor.
             it.description =
-                "Internal Kotlinx Benchmarks Configuration. Resolves dependencies required for running benchmark generators."
+                "Internal kotlinx-benchmark Configuration. Resolves dependencies required for running benchmark generators."
             it.resolvable()
 
             it.extendsFrom(benchmarkGenerator)

--- a/plugin/main/src/kotlinx/benchmark/gradle/internal/KotlinxBenchmarkPluginInternalApi.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/internal/KotlinxBenchmarkPluginInternalApi.kt
@@ -3,18 +3,18 @@ package kotlinx.benchmark.gradle.internal
 import kotlin.RequiresOptIn.Level.WARNING
 
 /**
- * Marks declarations that are **internal** to the Kotlinx Benchmark project.
+ * Marks declarations that are **internal** to the kotlinx-benchmark project.
  *
  * Classes or functions marked with this annotation have `public` visibility
  * for historical or technical reasons. They are not intended for use by
- * Kotlinx Benchmark users. They have no behaviour guarantees, and may lack clear
+ * kotlinx-benchmark users. They have no behaviour guarantees, and may lack clear
  * semantics, documentation, and backward compatibility.
  *
  * Please remove references to internal API to supported stable references.
  * If you still require access to these APIs, please raise an issue.
  */
 @RequiresOptIn(
-    message = "Internal Kotlinx Benchmark API. It may be changed in future releases without notice.",
+    message = "Internal kotlinx-benchmark API. It may be changed in future releases without notice.",
     level = WARNING,
 )
 @MustBeDocumented

--- a/plugin/main/src/kotlinx/benchmark/gradle/internal/generator/RequiresKotlinCompilerEmbeddable.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/internal/generator/RequiresKotlinCompilerEmbeddable.kt
@@ -1,0 +1,17 @@
+package kotlinx.benchmark.gradle.internal.generator
+
+import kotlin.RequiresOptIn.Level.ERROR
+
+/**
+ * This annotation indicates that a dependency on `kotlin-compiler-embeddable` is required at runtime.
+ *
+ * If code has this annotation, it **must** only be used inside a Gradle Worker with an isolated classpath.
+ * The worker must have `kotlin-compiler-embeddable` available on the classpath.
+ *
+ * @see kotlinx.benchmark.gradle.internal.generator.workers.GenerateJsSourceWorker
+ * @see kotlinx.benchmark.gradle.internal.generator.workers.GenerateWasmSourceWorker
+ * @see kotlinx.benchmark.gradle.NativeSourceGeneratorWorker
+ */
+@RequiresOptIn(level = ERROR)
+@MustBeDocumented
+internal annotation class RequiresKotlinCompilerEmbeddable

--- a/plugin/main/src/kotlinx/benchmark/gradle/internal/generator/workers/GenerateJsSourceWorker.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/internal/generator/workers/GenerateJsSourceWorker.kt
@@ -1,0 +1,85 @@
+package kotlinx.benchmark.gradle.internal.generator.workers
+
+import kotlinx.benchmark.gradle.KlibResolver
+import kotlinx.benchmark.gradle.Platform
+import kotlinx.benchmark.gradle.SuiteSourceGenerator
+import kotlinx.benchmark.gradle.createModuleDescriptor
+import kotlinx.benchmark.gradle.internal.generator.RequiresKotlinCompilerEmbeddable
+import org.gradle.api.file.*
+import org.gradle.api.provider.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.storage.LockBasedStorageManager
+import org.jetbrains.kotlin.storage.StorageManager
+import java.io.File
+
+/**
+ * Generates JavaScript benchmarking source code.
+ *
+ * This worker requires `kotlin-compiler-embeddable` and *must* be run in an isolated classpath.
+ *
+ * @see kotlinx.benchmark.gradle.JsSourceGeneratorTask
+ */
+@RequiresKotlinCompilerEmbeddable
+internal abstract class GenerateJsSourceWorker : WorkAction<GenerateJsSourceWorker.Params> {
+
+    internal interface Params : WorkParameters {
+        val title: Property<String>
+        val inputClasses: ConfigurableFileCollection
+        val inputDependencies: ConfigurableFileCollection
+        val outputSourcesDir: DirectoryProperty
+        val outputResourcesDir: DirectoryProperty
+        val useBenchmarkJs: Property<Boolean>
+    }
+
+    override fun execute() {
+        parameters.outputSourcesDir.get().asFile.deleteRecursively()
+        parameters.outputResourcesDir.get().asFile.deleteRecursively()
+
+        parameters.inputClasses.forEach { lib: File ->
+            generateSources(
+                title = parameters.title.get(),
+                lib = lib,
+                inputDependencies = parameters.inputDependencies.files,
+                outputSourcesDir = parameters.outputSourcesDir.get().asFile,
+                useBenchmarkJs = parameters.useBenchmarkJs.get(),
+            )
+        }
+    }
+
+    private fun generateSources(
+        title: String,
+        lib: File,
+        inputDependencies: Set<File>,
+        outputSourcesDir: File,
+        useBenchmarkJs: Boolean,
+    ) {
+        val modules = loadIr(
+            lib = lib,
+            inputDependencies = inputDependencies,
+            storageManager = LockBasedStorageManager("Inspect"),
+        )
+        modules.forEach { module ->
+            val generator = SuiteSourceGenerator(
+                title,
+                module,
+                outputSourcesDir,
+                if (useBenchmarkJs) Platform.JsBenchmarkJs else Platform.JsBuiltIn
+            )
+            generator.generate()
+        }
+    }
+
+    private fun loadIr(
+        lib: File,
+        inputDependencies: Set<File>,
+        storageManager: StorageManager,
+    ): List<ModuleDescriptor> {
+        // skip processing of empty dirs (fails if not to do it)
+        if (lib.listFiles() == null) return emptyList()
+        val dependencies = inputDependencies.filterNot { it.extension == "js" }.toSet()
+        val module = KlibResolver.JS.createModuleDescriptor(lib, dependencies, storageManager)
+        return listOf(module)
+    }
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/internal/generator/workers/GenerateWasmSourceWorker.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/internal/generator/workers/GenerateWasmSourceWorker.kt
@@ -1,0 +1,87 @@
+package kotlinx.benchmark.gradle.internal.generator.workers
+
+import kotlinx.benchmark.gradle.KlibResolver
+import kotlinx.benchmark.gradle.Platform
+import kotlinx.benchmark.gradle.SuiteSourceGenerator
+import kotlinx.benchmark.gradle.createModuleDescriptor
+import kotlinx.benchmark.gradle.internal.generator.RequiresKotlinCompilerEmbeddable
+import org.gradle.api.file.*
+import org.gradle.api.provider.*
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.storage.LockBasedStorageManager
+import org.jetbrains.kotlin.storage.StorageManager
+import java.io.File
+
+/**
+ * Generates Wasm benchmarking source code.
+ *
+ * This worker requires `kotlin-compiler-embeddable` and *must* be run in an isolated classpath.
+ *
+ * @see kotlinx.benchmark.gradle.WasmSourceGeneratorTask
+ */
+@RequiresKotlinCompilerEmbeddable
+internal abstract class GenerateWasmSourceWorker : WorkAction<GenerateWasmSourceWorker.Params> {
+
+    internal interface Params : WorkParameters {
+        val title: Property<String>
+        val inputClasses: ConfigurableFileCollection
+        val inputDependencies: ConfigurableFileCollection
+        val outputSourcesDir: DirectoryProperty
+        val outputResourcesDir: DirectoryProperty
+    }
+
+    override fun execute() {
+
+        val title = parameters.title.get()
+        val inputDependencies = parameters.inputDependencies.files
+        val outputSourcesDir = parameters.outputSourcesDir.get().asFile
+
+        parameters.outputSourcesDir.get().asFile.deleteRecursively()
+        parameters.outputResourcesDir.get().asFile.deleteRecursively()
+
+        parameters.inputClasses.forEach { lib: File ->
+            generateSources(
+                title = title,
+                lib = lib,
+                inputDependencies = inputDependencies,
+                outputSourcesDir = outputSourcesDir,
+            )
+        }
+    }
+
+    private fun generateSources(
+        title: String,
+        lib: File,
+        inputDependencies: Set<File>,
+        outputSourcesDir: File,
+    ) {
+        val modules = loadIr(
+            lib,
+            inputDependencies = inputDependencies,
+            LockBasedStorageManager("Inspect"),
+        )
+        modules.forEach { module ->
+            val generator = SuiteSourceGenerator(
+                title,
+                module,
+                outputSourcesDir,
+                Platform.WasmBuiltIn
+            )
+            generator.generate()
+        }
+    }
+
+    private fun loadIr(
+        lib: File,
+        inputDependencies: Set<File>,
+        storageManager: StorageManager,
+    ): List<ModuleDescriptor> {
+        //skip processing of empty dirs (fail if not to do it)
+        if (lib.listFiles() == null) return emptyList()
+        val dependencies = inputDependencies.filterNot { it.extension == "js" }.toSet()
+        val module = KlibResolver.JS.createModuleDescriptor(lib, dependencies, storageManager)
+        return listOf(module)
+    }
+}

--- a/runtime/commonMain/src/kotlinx/benchmark/internal/KotlinxBenchmarkPluginInternalApi.kt
+++ b/runtime/commonMain/src/kotlinx/benchmark/internal/KotlinxBenchmarkPluginInternalApi.kt
@@ -1,18 +1,18 @@
 package kotlinx.benchmark.internal
 
 /**
- * Marks declarations that are **internal** to the Kotlinx Benchmark project.
+ * Marks declarations that are **internal** to the kotlinx-benchmark project.
  *
  * Classes or functions marked with this annotation have `public` visibility
  * for historical or technical reasons. They are not intended for use by
- * Kotlinx Benchmark users. They have no behaviour guarantees, and may lack clear
+ * kotlinx-benchmark users. They have no behaviour guarantees, and may lack clear
  * semantics, documentation, and backward compatibility.
  *
  * Please remove references to internal API to supported stable references.
  * If you still require access to these APIs, please raise an issue.
  */
 @RequiresOptIn(
-    message = "Internal Kotlinx Benchmark API. It may be changed in future releases without notice.",
+    message = "Internal kotlinx-benchmark API. It may be changed in future releases without notice.",
     level = RequiresOptIn.Level.WARNING
 )
 @MustBeDocumented


### PR DESCRIPTION
Use Worker API to generate benchmark code

- Update the Benchmark JS/Wasm/Native source generation tasks to use the Worker API, so that `kotlin-compiler-embeddable` can be a compileOnly dependency, thus resolving https://youtrack.jetbrains.com/issue/KT-66764
- Create `GenerateJsSourceWorker` and `GenerateWasmSourceWorker` for isolating the JS and Wasm generation code. 
- Updated the Js/Wasm/Native generation tasks to invoke the source generators in a Worker isolated classpath.
- Created a new Configuration for declaring `kotlin-compiler-embeddable`, and pass it to the Js/Wasm/Native generation tasks. 
- Create a BenchmarkDependencies utility for defining all Configurations used in the plugin. (This also lays the groundwork for unifying the JMH version https://github.com/Kotlin/kotlinx-benchmark/issues/147#issuecomment-1980556088) 
- Updated BenchmarksPluginConstants to add `DEFAULT_KOTLIN_COMPILER_VERSION`, as sensible default for kotlin-compiler-embeddable.
- Add opt-in annotation RequiresKotlinCompilerEmbeddable to highlight code that requires `kotlin-compiler-embeddable`
- Some classes were updated to be `abstract`, to follow Gradle best practices for creating [managed objects](https://docs.gradle.org/8.8/userguide/properties_providers.html#managed_types).

I have tested this manually by running the Gradle Plugin tests with Kotlin version set to 2.0. However, Benchmarks is not compatible with KGP 2.0 as a KGP function has changed https://github.com/Kotlin/kotlinx-benchmark/issues/236. If I comment out this changed function, then Benchmarks works as expected.