### PR TITLE
Tune some kotlin-team-infra plugin parameters to unlock execution on macOS agents

### DIFF
--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -14,7 +14,7 @@ const val bintrayToken = "%env.BINTRAY_API_KEY%"
 const val libraryStagingRepoDescription = "kotlinx-benchmark"
 
 val platforms = Platform.values()
-const val jdk = "JDK_18_x64"
+const val jdk = "JDK_18"
 
 enum class Platform {
     Windows, Linux, MacOS;
@@ -70,6 +70,7 @@ fun Project.buildType(name: String, platform: Platform, configure: BuildType.() 
     params {
         // This parameter is needed for macOS agent to be compatible
         if (platform == Platform.MacOS) param("env.JDK_17", "")
+        if (platform == Platform.MacOS) param("env.JDK_16", "")
     }
 
     commonConfigure()


### PR DESCRIPTION
Currently, tasks are not scheduled to macOS agents as agents either don't have JDK16 installed, or are Apple Sillicon-based.
This PR overwrites corresponding tunables to unlock execution on macOS agents.