### PR TITLE
Add Kotlin version override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ buildscript {
 
         String kotlinVersion = providers.gradleProperty("kotlin_version").orNull
         if (kotlinVersion != null && !kotlinVersion.isBlank()) {
+            // In addition to overriding the Kotlin version in the Version Catalog,
+            // also enforce the KGP version using a dependency constraint.
+            // Constraints are stricter than Version Catalog.
             constraints {
                 classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt
 import tasks.CheckReadmeTask
 
 buildscript {
@@ -10,6 +11,13 @@ buildscript {
 
     dependencies {
         classpath(libs.kotlinx.teamInfraGradlePlugin)
+
+        String kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+        if (kotlinVersion != null && !kotlinVersion.isBlank()) {
+            constraints {
+                classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+            }
+        }
     }
 }
 
@@ -54,8 +62,15 @@ afterEvaluate {
 }
 //endregion
 
+String kgpVersion = KotlinPluginWrapperKt.getKotlinPluginVersion(project)
+logger.info("Using Kotlin ${KotlinPluginWrapperKt.getKotlinPluginVersion(it)}")
+
+String kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+if (kotlinVersion != null && kgpVersion != kotlinVersion) {
+    throw IllegalStateException("Expected that Kotlin version is overridden to $kotlinVersion, but is actually $kgpVersion")
+}
+
 allprojects {
-    logger.info("Using Kotlin ${libs.versions.kotlin.get()} for project $it")
     repositories {
         KotlinCommunity.addDevRepositoryIfEnabled(delegate, project)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,19 @@ afterEvaluate {
 }
 //endregion
 
-String kgpVersion = KotlinPluginWrapperKt.getKotlinPluginVersion(project)
-logger.info("Using Kotlin ${KotlinPluginWrapperKt.getKotlinPluginVersion(project)}")
+String currentKgpVersion = KotlinPluginWrapperKt.getKotlinPluginVersion(project)
+logger.info("Using Kotlin Gradle Plugin ${currentKgpVersion}")
 
-String kotlinVersion = providers.gradleProperty("kotlin_version").orNull
-if (kotlinVersion != null && kgpVersion != kotlinVersion) {
-    throw IllegalStateException("Expected that Kotlin version is overridden to $kotlinVersion, but is actually $kgpVersion")
+String kotlinVersionOverride = providers.gradleProperty("kotlin_version").getOrNull()
+
+if (kotlinVersionOverride != null) {
+    String versionCatalogKotlinVersion = libs.versions.kotlin.get()
+    if (kotlinVersionOverride != versionCatalogKotlinVersion) {
+        throw new IllegalStateException("Kotlin version in Version Catalog was not overridden. Expected:$kotlinVersionOverride, actual:$versionCatalogKotlinVersion.")
+    }
+    if (kotlinVersionOverride != currentKgpVersion) {
+        throw new IllegalStateException("Kotlin Gradle Plugin version was not overridden. Expected:$kotlinVersionOverride, actual:$currentKgpVersion.")
+    }
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ afterEvaluate {
 //endregion
 
 String kgpVersion = KotlinPluginWrapperKt.getKotlinPluginVersion(project)
-logger.info("Using Kotlin ${KotlinPluginWrapperKt.getKotlinPluginVersion(it)}")
+logger.info("Using Kotlin ${KotlinPluginWrapperKt.getKotlinPluginVersion(project)}")
 
 String kotlinVersion = providers.gradleProperty("kotlin_version").orNull
 if (kotlinVersion != null && kgpVersion != kotlinVersion) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 
+# Note: Kotlin version can be overridden by passing `-Pkotlin_dev=<version>`
 kotlin = "1.9.21"
 kotlinx-binaryCompatibilityValidator = "0.15.0-Beta.1"
 kotlinx-teamInfra = "0.4.0-dev-81"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-# Note: Kotlin version can be overridden by passing `-Pkotlin_dev=<version>`
+# Note: Kotlin version can be overridden by passing `-Pkotlin_version=<version>`
 kotlin = "1.9.21"
 kotlinx-binaryCompatibilityValidator = "0.15.0-Beta.1"
 kotlinx-teamInfra = "0.4.0-dev-81"

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -13,6 +13,10 @@ buildscript {
 
     dependencies {
         classpath(libs.kotlinx.teamInfraGradlePlugin)
+        // Note: unlike the root project, don't override KGP version in this project.
+        // Gradle plugins should only use the embedded-kotlin version.
+        // kotlinx-benchmark uses an external KGP the moment... but that should be fixed
+        // https://github.com/Kotlin/kotlinx-benchmark/issues/244
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,9 @@ dependencyResolutionManagement {
         create("libs") {
             String kotlinVersion = providers.gradleProperty("kotlin_version").orNull
             if (kotlinVersion != null && !kotlinVersion.isBlank()) {
+                // Override the default Kotlin version.
+                // The only intended use-case is for testing dev Kotlin builds using kotlinx-benchmark.
+                // The Kotlin version should not be overridden during regular development.
                 version("kotlin", kotlinVersion)
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,17 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            String kotlinVersion = providers.gradleProperty("kotlin_version").orNull
+            if (kotlinVersion != null && !kotlinVersion.isBlank()) {
+                version("kotlin", kotlinVersion)
+            }
+        }
+    }
+}
+
 rootProject.name = 'kotlinx-benchmark'
 
 includeBuild("plugin")


### PR DESCRIPTION
Add a dependency constraint in the root project to allow overriding the Kotlin version.

The Kotlin version is not overridden in the Benchmark Gradle plugin - this should use the version of Kotlin embedded into Gradle.

Add a check to ensure that the version is overridden.