### PR TITLE
Bump binary-compatibility-validator to 0.16.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 # Note: Kotlin version can be overridden by passing `-Pkotlin_version=<version>`
 kotlin = "1.9.21"
-kotlinx-binaryCompatibilityValidator = "0.15.0-Beta.1"
+kotlinx-binaryCompatibilityValidator = "0.16.2"
 kotlinx-teamInfra = "0.4.0-dev-81"
 squareup-kotlinpoet = "1.3.0"
 jmh = "1.21"


### PR DESCRIPTION
This is required to ensure compatibility of the build with Kotlin 2.1+ after resolving https://youtrack.jetbrains.com/issue/KT-61706