### PR TITLE
Introduce a workaround for apiCheck similar to apiDump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ tasks.register("apiDump") {
     it.dependsOn(gradle.includedBuild("plugin").task(":apiDump"))
 }
 
+tasks.register("apiCheck") {
+    it.dependsOn(gradle.includedBuild("plugin").task(":apiCheck"))
+}
+
 afterEvaluate {
     gradle.includedBuilds.forEach { included ->
         project(":kotlinx-benchmark-runtime").tasks.named("publishToMavenLocal") { dependsOn(included.task(":publishToMavenLocal")) }
@@ -110,4 +114,5 @@ tasks.register("checkReadme", CheckReadmeTask) {
 
 tasks.check {
     dependsOn(tasks.named("checkReadme"))
+    dependsOn(tasks.named("apiCheck"))
 }

--- a/plugin/api/kotlinx-benchmark-plugin.api
+++ b/plugin/api/kotlinx-benchmark-plugin.api
@@ -34,11 +34,12 @@ public class kotlinx/benchmark/gradle/BenchmarkTarget {
 	public final fun setWorkingDir (Ljava/lang/String;)V
 }
 
-public class kotlinx/benchmark/gradle/BenchmarksExtension {
+public abstract class kotlinx/benchmark/gradle/BenchmarksExtension {
 	public final fun configurations (Lgroovy/lang/Closure;)Lorg/gradle/api/NamedDomainObjectContainer;
 	public final fun getBenchsDescriptionDir ()Ljava/lang/String;
 	public final fun getBuildDir ()Ljava/lang/String;
 	public final fun getConfigurations ()Lorg/gradle/api/NamedDomainObjectContainer;
+	public abstract fun getKotlinCompilerVersion ()Lorg/gradle/api/provider/Property;
 	public final fun getProject ()Lorg/gradle/api/Project;
 	public final fun getReportsDir ()Ljava/lang/String;
 	public final fun getTargets ()Lorg/gradle/api/NamedDomainObjectContainer;
@@ -56,15 +57,8 @@ public final class kotlinx/benchmark/gradle/BenchmarksExtensionKt {
 public abstract class kotlinx/benchmark/gradle/BenchmarksPlugin : org/gradle/api/Plugin {
 	public static final field ASSEMBLE_BENCHMARKS_TASKNAME Ljava/lang/String;
 	public static final field BENCHMARKS_TASK_GROUP Ljava/lang/String;
-	public static final field BENCHMARK_COMPILATION_SUFFIX Ljava/lang/String;
-	public static final field BENCHMARK_COMPILE_SUFFIX Ljava/lang/String;
-	public static final field BENCHMARK_EXEC_SUFFIX Ljava/lang/String;
 	public static final field BENCHMARK_EXTENSION_NAME Ljava/lang/String;
-	public static final field BENCHMARK_GENERATE_SUFFIX Ljava/lang/String;
-	public static final field BENCHMARK_JAR_SUFFIX Ljava/lang/String;
 	public static final field Companion Lkotlinx/benchmark/gradle/BenchmarksPlugin$Companion;
-	public static final field JMH_CORE_DEPENDENCY Ljava/lang/String;
-	public static final field JMH_GENERATOR_DEPENDENCY Ljava/lang/String;
 	public static final field PLUGIN_ID Ljava/lang/String;
 	public static final field PLUGIN_VERSION Ljava/lang/String;
 	public static final field RUN_BENCHMARKS_TASKNAME Ljava/lang/String;
@@ -111,7 +105,7 @@ public final class kotlinx/benchmark/gradle/JsBenchmarksExecutor : java/lang/Enu
 	public static fun values ()[Lkotlinx/benchmark/gradle/JsBenchmarksExecutor;
 }
 
-public class kotlinx/benchmark/gradle/JsSourceGeneratorTask : org/gradle/api/DefaultTask {
+public abstract class kotlinx/benchmark/gradle/JsSourceGeneratorTask : org/gradle/api/DefaultTask {
 	public field inputClassesDirs Lorg/gradle/api/file/FileCollection;
 	public field inputDependencies Lorg/gradle/api/file/FileCollection;
 	public field outputResourcesDir Ljava/io/File;
@@ -122,6 +116,7 @@ public class kotlinx/benchmark/gradle/JsSourceGeneratorTask : org/gradle/api/Def
 	public final fun getInputDependencies ()Lorg/gradle/api/file/FileCollection;
 	public final fun getOutputResourcesDir ()Ljava/io/File;
 	public final fun getOutputSourcesDir ()Ljava/io/File;
+	public abstract fun getRuntimeClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun getUseBenchmarkJs ()Z
 	public final fun setInputClassesDirs (Lorg/gradle/api/file/FileCollection;)V
@@ -140,7 +135,7 @@ public abstract class kotlinx/benchmark/gradle/JvmBenchmarkTarget : kotlinx/benc
 public class kotlinx/benchmark/gradle/KotlinJvmBenchmarkTarget : kotlinx/benchmark/gradle/JvmBenchmarkTarget {
 }
 
-public class kotlinx/benchmark/gradle/NativeBenchmarkExec : org/gradle/api/DefaultTask {
+public abstract class kotlinx/benchmark/gradle/NativeBenchmarkExec : org/gradle/api/DefaultTask {
 	public field benchProgressPath Ljava/lang/String;
 	public field benchsDescriptionDir Ljava/io/File;
 	public field configFile Ljava/io/File;
@@ -164,9 +159,11 @@ public class kotlinx/benchmark/gradle/NativeBenchmarkExec : org/gradle/api/Defau
 }
 
 public final class kotlinx/benchmark/gradle/NativeBenchmarkTarget : kotlinx/benchmark/gradle/BenchmarkTarget {
+	public final fun getBuildType ()Lorg/jetbrains/kotlin/gradle/plugin/mpp/NativeBuildType;
+	public final fun setBuildType (Lorg/jetbrains/kotlin/gradle/plugin/mpp/NativeBuildType;)V
 }
 
-public class kotlinx/benchmark/gradle/NativeSourceGeneratorTask : org/gradle/api/DefaultTask {
+public abstract class kotlinx/benchmark/gradle/NativeSourceGeneratorTask : org/gradle/api/DefaultTask {
 	public field inputClassesDirs Lorg/gradle/api/file/FileCollection;
 	public field inputDependencies Lorg/gradle/api/file/FileCollection;
 	public field nativeTarget Ljava/lang/String;
@@ -179,6 +176,7 @@ public class kotlinx/benchmark/gradle/NativeSourceGeneratorTask : org/gradle/api
 	public final fun getNativeTarget ()Ljava/lang/String;
 	public final fun getOutputResourcesDir ()Ljava/io/File;
 	public final fun getOutputSourcesDir ()Ljava/io/File;
+	public abstract fun getRuntimeClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun setInputClassesDirs (Lorg/gradle/api/file/FileCollection;)V
 	public final fun setInputDependencies (Lorg/gradle/api/file/FileCollection;)V
@@ -196,7 +194,7 @@ public final class kotlinx/benchmark/gradle/UtilsKt$sam$i$org_gradle_api_Action$
 public final class kotlinx/benchmark/gradle/WasmBenchmarkTarget : kotlinx/benchmark/gradle/BenchmarkTarget {
 }
 
-public class kotlinx/benchmark/gradle/WasmSourceGeneratorTask : org/gradle/api/DefaultTask {
+public abstract class kotlinx/benchmark/gradle/WasmSourceGeneratorTask : org/gradle/api/DefaultTask {
 	public field inputClassesDirs Lorg/gradle/api/file/FileCollection;
 	public field inputDependencies Lorg/gradle/api/file/FileCollection;
 	public field outputResourcesDir Ljava/io/File;
@@ -207,6 +205,7 @@ public class kotlinx/benchmark/gradle/WasmSourceGeneratorTask : org/gradle/api/D
 	public final fun getInputDependencies ()Lorg/gradle/api/file/FileCollection;
 	public final fun getOutputResourcesDir ()Ljava/io/File;
 	public final fun getOutputSourcesDir ()Ljava/io/File;
+	public abstract fun getRuntimeClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun setInputClassesDirs (Lorg/gradle/api/file/FileCollection;)V
 	public final fun setInputDependencies (Lorg/gradle/api/file/FileCollection;)V

--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksPlugin.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarksPlugin.kt
@@ -30,8 +30,6 @@ constructor(
         const val ASSEMBLE_BENCHMARKS_TASKNAME = "assembleBenchmarks"
 
         //region Internal constants
-        // Note that despite the @InternalApi annotation, `const val`s are still present in the API Dump
-        // https://github.com/Kotlin/binary-compatibility-validator/issues/90
         @KotlinxBenchmarkPluginInternalApi
         const val BENCHMARK_GENERATE_SUFFIX = "BenchmarkGenerate"
 

--- a/runtime/api/kotlinx-benchmark-runtime.klib.api
+++ b/runtime/api/kotlinx-benchmark-runtime.klib.api
@@ -6,61 +6,24 @@
 // - Show declarations: true
 
 // Library unique name: <org.jetbrains.kotlinx:kotlinx-benchmark-runtime>
-final class kotlinx.benchmark/Blackhole { // kotlinx.benchmark/Blackhole|null[0]
-    constructor <init>() // kotlinx.benchmark/Blackhole.<init>|<init>(){}[0]
-    final inline fun consume(kotlin/Any?) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Any?){}[0]
-    final inline fun consume(kotlin/Boolean) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Boolean){}[0]
-    final inline fun consume(kotlin/Byte) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Byte){}[0]
-    final inline fun consume(kotlin/Char) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Char){}[0]
-    final inline fun consume(kotlin/Double) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Double){}[0]
-    final inline fun consume(kotlin/Float) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Float){}[0]
-    final inline fun consume(kotlin/Int) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Int){}[0]
-    final inline fun consume(kotlin/Long) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Long){}[0]
-    final inline fun consume(kotlin/Short) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Short){}[0]
-    // Targets: [js.jsIr, wasmJs]
-    final fun consumeAny(kotlin/Any?) // kotlinx.benchmark/Blackhole.consumeAny|consumeAny(kotlin.Any?){}[0]
-    // Targets: [js.jsIr, wasmJs]
-    final fun consumeInt(kotlin/Int) // kotlinx.benchmark/Blackhole.consumeInt|consumeInt(kotlin.Int){}[0]
-}
-final enum class kotlinx.benchmark/BenchmarkTimeUnit : kotlin/Enum<kotlinx.benchmark/BenchmarkTimeUnit> { // kotlinx.benchmark/BenchmarkTimeUnit|null[0]
-    enum entry MICROSECONDS // kotlinx.benchmark/BenchmarkTimeUnit.MICROSECONDS|null[0]
-    enum entry MILLISECONDS // kotlinx.benchmark/BenchmarkTimeUnit.MILLISECONDS|null[0]
-    enum entry MINUTES // kotlinx.benchmark/BenchmarkTimeUnit.MINUTES|null[0]
-    enum entry NANOSECONDS // kotlinx.benchmark/BenchmarkTimeUnit.NANOSECONDS|null[0]
-    enum entry SECONDS // kotlinx.benchmark/BenchmarkTimeUnit.SECONDS|null[0]
-    final fun valueOf(kotlin/String): kotlinx.benchmark/BenchmarkTimeUnit // kotlinx.benchmark/BenchmarkTimeUnit.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<kotlinx.benchmark/BenchmarkTimeUnit> // kotlinx.benchmark/BenchmarkTimeUnit.values|values#static(){}[0]
-    final val entries // kotlinx.benchmark/BenchmarkTimeUnit.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.benchmark/BenchmarkTimeUnit> // kotlinx.benchmark/BenchmarkTimeUnit.entries.<get-entries>|<get-entries>#static(){}[0]
-}
-final enum class kotlinx.benchmark/Mode : kotlin/Enum<kotlinx.benchmark/Mode> { // kotlinx.benchmark/Mode|null[0]
-    enum entry AverageTime // kotlinx.benchmark/Mode.AverageTime|null[0]
-    enum entry Throughput // kotlinx.benchmark/Mode.Throughput|null[0]
-    final fun valueOf(kotlin/String): kotlinx.benchmark/Mode // kotlinx.benchmark/Mode.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<kotlinx.benchmark/Mode> // kotlinx.benchmark/Mode.values|values#static(){}[0]
-    final val entries // kotlinx.benchmark/Mode.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.benchmark/Mode> // kotlinx.benchmark/Mode.entries.<get-entries>|<get-entries>#static(){}[0]
-}
-final enum class kotlinx.benchmark/Scope : kotlin/Enum<kotlinx.benchmark/Scope> { // kotlinx.benchmark/Scope|null[0]
-    enum entry Benchmark // kotlinx.benchmark/Scope.Benchmark|null[0]
-    final fun valueOf(kotlin/String): kotlinx.benchmark/Scope // kotlinx.benchmark/Scope.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<kotlinx.benchmark/Scope> // kotlinx.benchmark/Scope.values|values#static(){}[0]
-    final val entries // kotlinx.benchmark/Scope.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.benchmark/Scope> // kotlinx.benchmark/Scope.entries.<get-entries>|<get-entries>#static(){}[0]
-}
 open annotation class kotlinx.benchmark.internal/KotlinxBenchmarkRuntimeInternalApi : kotlin/Annotation { // kotlinx.benchmark.internal/KotlinxBenchmarkRuntimeInternalApi|null[0]
     constructor <init>() // kotlinx.benchmark.internal/KotlinxBenchmarkRuntimeInternalApi.<init>|<init>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/Benchmark : kotlin/Annotation { // kotlinx.benchmark/Benchmark|null[0]
     constructor <init>() // kotlinx.benchmark/Benchmark.<init>|<init>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/BenchmarkMode : kotlin/Annotation { // kotlinx.benchmark/BenchmarkMode|null[0]
     constructor <init>(kotlin/Array<out kotlinx.benchmark/Mode>...) // kotlinx.benchmark/BenchmarkMode.<init>|<init>(kotlin.Array<out|kotlinx.benchmark.Mode>...){}[0]
+
     final val value // kotlinx.benchmark/BenchmarkMode.value|{}value[0]
         final fun <get-value>(): kotlin/Array<out kotlinx.benchmark/Mode> // kotlinx.benchmark/BenchmarkMode.value.<get-value>|<get-value>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/Measurement : kotlin/Annotation { // kotlinx.benchmark/Measurement|null[0]
     constructor <init>(kotlin/Int =..., kotlin/Int =..., kotlinx.benchmark/BenchmarkTimeUnit =..., kotlin/Int =...) // kotlinx.benchmark/Measurement.<init>|<init>(kotlin.Int;kotlin.Int;kotlinx.benchmark.BenchmarkTimeUnit;kotlin.Int){}[0]
+
     final val batchSize // kotlinx.benchmark/Measurement.batchSize|{}batchSize[0]
         final fun <get-batchSize>(): kotlin/Int // kotlinx.benchmark/Measurement.batchSize.<get-batchSize>|<get-batchSize>(){}[0]
     final val iterations // kotlinx.benchmark/Measurement.iterations|{}iterations[0]
@@ -70,29 +33,39 @@ open annotation class kotlinx.benchmark/Measurement : kotlin/Annotation { // kot
     final val timeUnit // kotlinx.benchmark/Measurement.timeUnit|{}timeUnit[0]
         final fun <get-timeUnit>(): kotlinx.benchmark/BenchmarkTimeUnit // kotlinx.benchmark/Measurement.timeUnit.<get-timeUnit>|<get-timeUnit>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/OutputTimeUnit : kotlin/Annotation { // kotlinx.benchmark/OutputTimeUnit|null[0]
     constructor <init>(kotlinx.benchmark/BenchmarkTimeUnit) // kotlinx.benchmark/OutputTimeUnit.<init>|<init>(kotlinx.benchmark.BenchmarkTimeUnit){}[0]
+
     final val value // kotlinx.benchmark/OutputTimeUnit.value|{}value[0]
         final fun <get-value>(): kotlinx.benchmark/BenchmarkTimeUnit // kotlinx.benchmark/OutputTimeUnit.value.<get-value>|<get-value>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/Param : kotlin/Annotation { // kotlinx.benchmark/Param|null[0]
     constructor <init>(kotlin/Array<out kotlin/String>...) // kotlinx.benchmark/Param.<init>|<init>(kotlin.Array<out|kotlin.String>...){}[0]
+
     final val value // kotlinx.benchmark/Param.value|{}value[0]
         final fun <get-value>(): kotlin/Array<out kotlin/String> // kotlinx.benchmark/Param.value.<get-value>|<get-value>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/Setup : kotlin/Annotation { // kotlinx.benchmark/Setup|null[0]
     constructor <init>() // kotlinx.benchmark/Setup.<init>|<init>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/State : kotlin/Annotation { // kotlinx.benchmark/State|null[0]
     constructor <init>(kotlinx.benchmark/Scope) // kotlinx.benchmark/State.<init>|<init>(kotlinx.benchmark.Scope){}[0]
+
     final val value // kotlinx.benchmark/State.value|{}value[0]
         final fun <get-value>(): kotlinx.benchmark/Scope // kotlinx.benchmark/State.value.<get-value>|<get-value>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/TearDown : kotlin/Annotation { // kotlinx.benchmark/TearDown|null[0]
     constructor <init>() // kotlinx.benchmark/TearDown.<init>|<init>(){}[0]
 }
+
 open annotation class kotlinx.benchmark/Warmup : kotlin/Annotation { // kotlinx.benchmark/Warmup|null[0]
     constructor <init>(kotlin/Int =..., kotlin/Int =..., kotlinx.benchmark/BenchmarkTimeUnit =..., kotlin/Int =...) // kotlinx.benchmark/Warmup.<init>|<init>(kotlin.Int;kotlin.Int;kotlinx.benchmark.BenchmarkTimeUnit;kotlin.Int){}[0]
+
     final val batchSize // kotlinx.benchmark/Warmup.batchSize|{}batchSize[0]
         final fun <get-batchSize>(): kotlin/Int // kotlinx.benchmark/Warmup.batchSize.<get-batchSize>|<get-batchSize>(){}[0]
     final val iterations // kotlinx.benchmark/Warmup.iterations|{}iterations[0]
@@ -101,4 +74,59 @@ open annotation class kotlinx.benchmark/Warmup : kotlin/Annotation { // kotlinx.
         final fun <get-time>(): kotlin/Int // kotlinx.benchmark/Warmup.time.<get-time>|<get-time>(){}[0]
     final val timeUnit // kotlinx.benchmark/Warmup.timeUnit|{}timeUnit[0]
         final fun <get-timeUnit>(): kotlinx.benchmark/BenchmarkTimeUnit // kotlinx.benchmark/Warmup.timeUnit.<get-timeUnit>|<get-timeUnit>(){}[0]
+}
+
+final enum class kotlinx.benchmark/BenchmarkTimeUnit : kotlin/Enum<kotlinx.benchmark/BenchmarkTimeUnit> { // kotlinx.benchmark/BenchmarkTimeUnit|null[0]
+    enum entry MICROSECONDS // kotlinx.benchmark/BenchmarkTimeUnit.MICROSECONDS|null[0]
+    enum entry MILLISECONDS // kotlinx.benchmark/BenchmarkTimeUnit.MILLISECONDS|null[0]
+    enum entry MINUTES // kotlinx.benchmark/BenchmarkTimeUnit.MINUTES|null[0]
+    enum entry NANOSECONDS // kotlinx.benchmark/BenchmarkTimeUnit.NANOSECONDS|null[0]
+    enum entry SECONDS // kotlinx.benchmark/BenchmarkTimeUnit.SECONDS|null[0]
+
+    final val entries // kotlinx.benchmark/BenchmarkTimeUnit.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.benchmark/BenchmarkTimeUnit> // kotlinx.benchmark/BenchmarkTimeUnit.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): kotlinx.benchmark/BenchmarkTimeUnit // kotlinx.benchmark/BenchmarkTimeUnit.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<kotlinx.benchmark/BenchmarkTimeUnit> // kotlinx.benchmark/BenchmarkTimeUnit.values|values#static(){}[0]
+}
+
+final enum class kotlinx.benchmark/Mode : kotlin/Enum<kotlinx.benchmark/Mode> { // kotlinx.benchmark/Mode|null[0]
+    enum entry AverageTime // kotlinx.benchmark/Mode.AverageTime|null[0]
+    enum entry Throughput // kotlinx.benchmark/Mode.Throughput|null[0]
+
+    final val entries // kotlinx.benchmark/Mode.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.benchmark/Mode> // kotlinx.benchmark/Mode.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): kotlinx.benchmark/Mode // kotlinx.benchmark/Mode.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<kotlinx.benchmark/Mode> // kotlinx.benchmark/Mode.values|values#static(){}[0]
+}
+
+final enum class kotlinx.benchmark/Scope : kotlin/Enum<kotlinx.benchmark/Scope> { // kotlinx.benchmark/Scope|null[0]
+    enum entry Benchmark // kotlinx.benchmark/Scope.Benchmark|null[0]
+
+    final val entries // kotlinx.benchmark/Scope.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<kotlinx.benchmark/Scope> // kotlinx.benchmark/Scope.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): kotlinx.benchmark/Scope // kotlinx.benchmark/Scope.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<kotlinx.benchmark/Scope> // kotlinx.benchmark/Scope.values|values#static(){}[0]
+}
+
+final class kotlinx.benchmark/Blackhole { // kotlinx.benchmark/Blackhole|null[0]
+    constructor <init>() // kotlinx.benchmark/Blackhole.<init>|<init>(){}[0]
+
+    final inline fun consume(kotlin/Any?) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Any?){}[0]
+    final inline fun consume(kotlin/Boolean) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Boolean){}[0]
+    final inline fun consume(kotlin/Byte) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Byte){}[0]
+    final inline fun consume(kotlin/Char) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Char){}[0]
+    final inline fun consume(kotlin/Double) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Double){}[0]
+    final inline fun consume(kotlin/Float) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Float){}[0]
+    final inline fun consume(kotlin/Int) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Int){}[0]
+    final inline fun consume(kotlin/Long) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Long){}[0]
+    final inline fun consume(kotlin/Short) // kotlinx.benchmark/Blackhole.consume|consume(kotlin.Short){}[0]
+
+    // Targets: [js.jsIr, wasmJs]
+    final fun consumeAny(kotlin/Any?) // kotlinx.benchmark/Blackhole.consumeAny|consumeAny(kotlin.Any?){}[0]
+
+    // Targets: [js.jsIr, wasmJs]
+    final fun consumeInt(kotlin/Int) // kotlinx.benchmark/Blackhole.consumeInt|consumeInt(kotlin.Int){}[0]
 }


### PR DESCRIPTION
Also, update the dump to reflect the actual state of the Gradle plugin. Reorders entries in the dumps: https://github.com/Kotlin/binary-compatibility-validator/pull/225, https://github.com/Kotlin/binary-compatibility-validator/issues/196 Removes internal constants from the dump: https://github.com/Kotlin/binary-compatibility-validator/issues/90 Fixes #248