### PR TITLE
Fix Native Benchmark Compilations triggering compile tasks on Gradle sync

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -74,14 +74,8 @@ private fun Project.createNativeBenchmarkCompileTask(target: NativeBenchmarkTarg
         sourceSet.resources.setSrcDirs(files())
         sourceSet.kotlin.setSrcDirs(files("$benchmarkBuildDir/sources"))
 
-        sourceSet.dependencies {
-            implementation(compilation.output.allOutputs)
-        }
-        project.configurations.let {
-            it.getByName(sourceSet.implementationConfigurationName).extendsFrom(
-                it.getByName(compilation.compileDependencyConfigurationName)
-            )
-        }
+        associateWith(compilation)
+
 
         // TODO: check if there are other ways to set compiler options.
         this.kotlinOptions.freeCompilerArgs = compilation.kotlinOptions.freeCompilerArgs


### PR DESCRIPTION
... by using `associateWith` instead of manually wiring up compile outputs back to the `implementation` dependency of the benchmark compilation.

Tested using the `kotlinx.io` project. 
**Before**:
![before](https://github.com/user-attachments/assets/2f441388-3379-4e7c-8fea-db606e8de632)

**After**:
<img width="877" alt="image" src="https://github.com/user-attachments/assets/b4b6008b-94e9-4957-8af0-d63b34cadd04">

