### PR TITLE
Add support for non-packed klib files in the native generator

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeSourceGeneratorTask.kt
@@ -100,7 +100,8 @@ abstract class NativeSourceGeneratorWorker : WorkAction<NativeSourceGeneratorWor
         parameters.outputSourcesDir.deleteRecursively()
         parameters.outputResourcesDir.deleteRecursively()
         parameters.inputClassesDirs
-            .filter { it.exists() && it.name.endsWith(KLIB_FILE_EXTENSION_WITH_DOT) }
+            // expect either a packed .klib file or non-packed klib directory
+            .filter { it.exists() && it.name.endsWith(KLIB_FILE_EXTENSION_WITH_DOT) || it.isDirectory && it.resolve("default/manifest").isFile }
             .forEach { lib ->
                 if (parameters.target.isEmpty())
                     throw Exception("nativeTarget should be specified for API generator for native targets")


### PR DESCRIPTION
Relates to [KT-65285](https://youtrack.jetbrains.com/issue/KT-65285)

Fixes integration tests with Kotlin that contains this feature