### PR TITLE
Override Kotlin apiVersion and languageVersion compiler options …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import kotlinx.team.infra.InfraExtension
 import kotlinx.validation.ExperimentalBCVApi
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import tasks.CheckReadmeTask
 
 buildscript {
@@ -92,6 +94,20 @@ if (kotlinVersionOverride != null) {
 allprojects {
     repositories {
         addDevRepositoryIfEnabled(this, project)
+    }
+
+    tasks.withType<KotlinCompilationTask<*>>().configureEach {
+        compilerOptions {
+            getOverriddenKotlinLanguageVersion(project)?.let {
+                languageVersion = KotlinVersion.fromVersion(it)
+            }
+            getOverriddenKotlinApiVersion(project)?.let {
+                apiVersion = KotlinVersion.fromVersion(it)
+            }
+
+            progressiveMode = true
+            allWarningsAsErrors = true
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/KotlinCommunity.kt
+++ b/buildSrc/src/main/kotlin/KotlinCommunity.kt
@@ -3,7 +3,6 @@
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.*
 import java.net.*
-import java.util.logging.Logger
 
 /*
  * Functions in this file are responsible for configuring kotlinx-benchmarks build against a custom dev version
@@ -22,8 +21,8 @@ import java.util.logging.Logger
  *   empty string otherwise
  */
 fun getKotlinDevRepositoryUrl(project: Project): String? {
-    val url = project.rootProject.properties["kotlin_repo_url"] as? String
-    if (url != null) {
+    val url = project.providers.gradleProperty("kotlin_repo_url").orNull
+    if (!url.isNullOrBlank()) {
         project.logger.info("""Configured Kotlin Compiler repository url: '$url' for project ${project.name}""")
     }
     return url
@@ -37,4 +36,30 @@ fun addDevRepositoryIfEnabled(repositoryHandler: RepositoryHandler, project: Pro
     repositoryHandler.maven {
         url = URI.create(devRepoUrl)
     }
+}
+
+/**
+ * Should be used for running against non-released Kotlin compiler on a system test level.
+ *
+ * @return a Kotlin API version parametrized from command line or gradle.properties, null otherwise
+ */
+fun getOverriddenKotlinApiVersion(project: Project): String? {
+    val apiVersion = project.providers.gradleProperty("kotlin_api_version").orNull
+    if (!apiVersion.isNullOrBlank()) {
+        project.logger.info("""Configured Kotlin API version: '$apiVersion' for project ${project.name}""")
+    }
+    return apiVersion
+}
+
+/**
+ * Should be used for running against non-released Kotlin compiler on a system test level.
+ *
+ * @return a Kotlin Language version parametrized from command line or gradle.properties, null otherwise
+ */
+fun getOverriddenKotlinLanguageVersion(project: Project): String? {
+    val languageVersion = project.providers.gradleProperty("kotlin_language_version").orNull
+    if (!languageVersion.isNullOrBlank()) {
+        project.logger.info("""Configured Kotlin Language version: '$languageVersion' for project ${project.name}""")
+    }
+    return languageVersion
 }

--- a/examples/kotlin-multiplatform/build.gradle
+++ b/examples/kotlin-multiplatform/build.gradle
@@ -30,18 +30,6 @@ kotlin {
 
     applyDefaultHierarchyTemplate()
 
-    targets.configureEach {
-        compilations.configureEach {
-            kotlinOptions.allWarningsAsErrors = true
-        }
-    }
-
-    sourceSets.configureEach {
-        languageSettings {
-            progressiveMode = true
-        }
-    }
-
     sourceSets {
         commonMain {
             dependencies {

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -23,8 +23,16 @@ tasks.test {
 
     systemProperty("plugin_repo_url", plugin.projectDir.resolve("build/maven").absoluteFile.invariantSeparatorsPath)
     systemProperty("runtime_repo_url", rootProject.buildDir.resolve("maven").absoluteFile.invariantSeparatorsPath)
-    systemProperty("kotlin_repo_url", rootProject.properties["kotlin_repo_url"])
+    getKotlinDevRepositoryUrl(project)?.let {
+        systemProperty("kotlin_repo_url", it)
+    }
     systemProperty("kotlin_version", libs.versions.kotlin.asProvider().get())
+    getOverriddenKotlinLanguageVersion(project)?.let {
+        systemProperty("kotlin_language_version", it)
+    }
+    getOverriddenKotlinApiVersion(project)?.let {
+        systemProperty("kotlin_api_version", it)
+    }
     systemProperty("minSupportedGradleVersion", libs.versions.minSupportedGradle.get())
     systemProperty("minSupportedKotlinVersion", libs.versions.minSupportedKotlin.get())
 }

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/ProjectBuilder.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/ProjectBuilder.kt
@@ -32,16 +32,32 @@ benchmark {
     }
 }
 
-private val kotlin_repo = System.getProperty("kotlin_repo_url").let {
-    if (it.isNullOrBlank()) "" else "maven { url '$it' }"
+private val kotlin_repo = System.getProperty("kotlin_repo_url")?.let {
+    "maven { url '$it' }"
+}.orEmpty()
+
+private val plugin_repo_url = System.getProperty("plugin_repo_url")!!.let {
+    "maven { url '$it' }"
 }
+
+private val runtime_repo_url = System.getProperty("runtime_repo_url")!!.let {
+    "maven { url '$it' }"
+}
+
+private val kotlin_language_version = System.getProperty("kotlin_language_version")?.let {
+    "languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion('$it')"
+}.orEmpty()
+
+private val kotlin_api_version = System.getProperty("kotlin_api_version")?.let {
+    "apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion('$it')"
+}.orEmpty()
 
 private fun generateBuildScript(kotlinVersion: String, jvmToolchain: Int) =
     """
     buildscript {
         repositories {
             $kotlin_repo
-            maven { url '${System.getProperty("plugin_repo_url")}' }
+            $plugin_repo_url
             mavenCentral()
         }
         dependencies {
@@ -55,11 +71,21 @@ private fun generateBuildScript(kotlinVersion: String, jvmToolchain: Int) =
     
     repositories {
         $kotlin_repo
-        maven { url '${System.getProperty("runtime_repo_url")}' }
+        $runtime_repo_url
         mavenCentral()
     }
     
     kotlin {
         jvmToolchain($jvmToolchain)
+    }
+    
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask).configureEach {
+        compilerOptions {
+            $kotlin_language_version
+            $kotlin_api_version
+
+            progressiveMode = true
+            allWarningsAsErrors = true
+        }
     }
     """.trimIndent()

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -59,13 +59,14 @@ kotlin {
 
     targets.configureEach {
         compilations.configureEach {
-            compilerOptions.configure {
-                allWarningsAsErrors = true
-                freeCompilerArgs.add("-Xexpect-actual-classes")
-                optIn.addAll(
-                    "kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi",
-                    "kotlin.RequiresOptIn",
-                )
+            compileTaskProvider.configure {
+                compilerOptions {
+                    freeCompilerArgs.add("-Xexpect-actual-classes")
+                    optIn.addAll(
+                        "kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi",
+                        "kotlin.RequiresOptIn",
+                    )
+                }
             }
         }
     }
@@ -73,9 +74,6 @@ kotlin {
     sourceSets.configureEach {
         kotlin.srcDirs(listOf("$name/src"))
         resources.srcDirs(listOf("$name/resources"))
-        languageSettings {
-            progressiveMode = true
-        }
     }
 
     sourceSets {


### PR DESCRIPTION
…with Gradle properties.

This is needed for building the library as a part of TeamCity aggregate builds.