### PR TITLE
Forward the kotlin.native.version parameter to test projects

### DIFF
--- a/buildSrc/src/main/kotlin/KotlinCommunity.kt
+++ b/buildSrc/src/main/kotlin/KotlinCommunity.kt
@@ -63,3 +63,16 @@ fun getOverriddenKotlinLanguageVersion(project: Project): String? {
     }
     return languageVersion
 }
+
+/**
+ * Should be used for running against non-released Kotlin compiler on a system test level.
+ *
+ * @return a Kotlin API version parametrized from command line or gradle.properties, null otherwise
+ */
+fun getOverriddenKotlinNativeVersion(project: Project): String? {
+    val nativeVersion = project.providers.gradleProperty("kotlin.native.version").orNull
+    if (!nativeVersion.isNullOrBlank()) {
+        project.logger.info("""Configured Kotlin Native distribution version: '$nativeVersion' for project ${project.name}""")
+    }
+    return nativeVersion
+}

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -33,6 +33,9 @@ tasks.test {
     getOverriddenKotlinApiVersion(project)?.let {
         systemProperty("kotlin_api_version", it)
     }
+    getOverriddenKotlinNativeVersion(project)?.let {
+        systemProperty("kotlin.native.version", it)
+    }
     systemProperty("minSupportedGradleVersion", libs.versions.minSupportedGradle.get())
     systemProperty("minSupportedKotlinVersion", libs.versions.minSupportedKotlin.get())
 }

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/Runner.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/Runner.kt
@@ -16,7 +16,7 @@ class Runner(
     private fun gradle(vararg tasks: String): GradleRunner =
         GradleRunner.create()
             .withProjectDir(projectDir)
-            .withArguments(*(defaultArguments() + tasks))
+            .withArguments(*(defaultArguments() + kotlinNativeVersion + tasks))
             .withGradleVersion(gradleVersion.versionString)
             .forwardStdError(System.err.bufferedWriter())
             .run {
@@ -43,6 +43,11 @@ class Runner(
     }
 
     private fun defaultArguments(): Array<String> = arrayOf("--stacktrace")
+
+    // Forward the Kotlin Native distribution version to test projects
+    private val kotlinNativeVersion = "kotlin.native.version".let { property ->
+        System.getProperty(property)?.let { arrayOf("-P$property=$it") } ?: emptyArray()
+    }
 
     fun updateAnnotations(filePath: String, annotationsSpecifier: AnnotationsSpecifier.() -> Unit) {
         val annotations = AnnotationsSpecifier().also(annotationsSpecifier)


### PR DESCRIPTION
This is needed for building the library as a part of TeamCity aggregate builds.