### PR TITLE
Add a TC build config for building with Kotlin master

### DIFF
--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -106,8 +106,7 @@ fun Project.buildWithKotlinMaster(platform: Platform, versionBuild: BuildType) =
         artifacts {
             buildRule = lastSuccessful()
             cleanDestination = true
-            artifactRules = "+:maven.zip!**=>artifacts/kotlin\n" +
-                    "+:kotlin-native-prebuilt-linux-x86_64-%$kotlinVersionParameter%.tar.gz!**=>artifacts/native"
+            artifactRules = "+:maven.zip!**=>artifacts/kotlin"
         }
     }
 

--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -9,7 +9,6 @@ import jetbrains.buildServer.configs.kotlin.DslContext
 import jetbrains.buildServer.configs.kotlin.ParameterDisplay
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
-import jetbrains.buildServer.configs.kotlin.buildSteps.GradleBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.gradle
 
 fun Project.additionalConfiguration() {
@@ -28,9 +27,6 @@ fun Project.additionalConfiguration() {
         }
     }
     platforms.forEach { platform ->
-        val gradleBuild = knownBuilds.buildOn(platform).steps.items.single() as GradleBuildStep
-        gradleBuild.tasks += " " + "fastBenchmark"
-
         knownBuilds.deployPublish.params {
             select("reverse.dep.*.system.publication_repository", "space", display = ParameterDisplay.PROMPT, label = "Publication Repository", options = listOf("space", "sonatype"))
         }


### PR DESCRIPTION
Such a build configuration is useful for catching new changes that are not compatible with the latest Kotlin build.
For details see https://youtrack.jetbrains.com/articles/KT-A-297/Libraries-develop-and-Kotlin-master-checks