### PR TITLE
Do not log KMP host messages at warning level

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -18,7 +18,7 @@ fun Project.processNativeCompilation(target: NativeBenchmarkTarget) {
     val expectedHost = compilation.target.konanTarget
     val actualHost = HostManager.host
     if (expectedHost != actualHost) {
-        project.logger.warn("Skipping benchmarks for '${target.name}' because they cannot be run on current host '$actualHost' (expected host: '$expectedHost')")
+        project.logger.info("Skipping benchmarks for '${target.name}' because they cannot be run on current host '$actualHost' (expected host: '$expectedHost')")
         return
     }
 


### PR DESCRIPTION
Constantly logging these messages at warning level is not useful.

#105