### PR TITLE
Use nodejs for wasmJs target

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -45,7 +45,10 @@ kotlin {
     jvm()
     js { nodejs() }
     @OptIn(ExperimentalWasmDsl::class)
-    wasmJs { d8() }
+    wasmJs {
+        nodejs()
+        d8()
+    }
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     applyDefaultHierarchyTemplate {


### PR DESCRIPTION
It is necessary to use NPM related subtarget to be compatible with examples/kotlin-multiplatform. D8 is subtarget without necessity in NPM.