### PR TITLE
Fix assorted problems with K/JS projects

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinJsTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinJsTest.kt
@@ -1,0 +1,26 @@
+package kotlinx.benchmark.integration
+
+import kotlin.test.Test
+
+class KotlinJsTest : GradleTest() {
+    @Test
+    fun useEsModules() {
+        project("es-modules", true).runAndSucceed("jsEsBenchmark") {
+            assertOutputContains("CommonBenchmark.benchmark")
+        }
+    }
+
+    @Test
+    fun useUmdModules() {
+        project("es-modules", true).runAndSucceed("jsUmdBenchmark") {
+            assertOutputContains("CommonBenchmark.benchmark")
+        }
+    }
+
+    @Test
+    fun useCommonJs() {
+        project("es-modules", true).runAndSucceed("jsCommonBenchmark") {
+            assertOutputContains("CommonBenchmark.benchmark")
+        }
+    }
+}

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ProjectWithResourceFilesTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ProjectWithResourceFilesTest.kt
@@ -1,0 +1,27 @@
+package kotlinx.benchmark.integration
+
+import org.junit.Test
+
+// Regression tests for #185
+class ProjectWithResourceFilesTest : GradleTest() {
+    private fun verifyFor(target: String) {
+        project("project-with-resources", true).let { runner ->
+            runner.runAndSucceed("${target}Benchmark")
+        }
+    }
+
+    @Test
+    fun js() {
+        verifyFor("js")
+    }
+
+    @Test
+    fun native() {
+        verifyFor("native")
+    }
+
+    @Test
+    fun wasmJs() {
+        verifyFor("wasmJs")
+    }
+}

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/TransitiveDependenciesResolutionTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/TransitiveDependenciesResolutionTest.kt
@@ -1,0 +1,27 @@
+package kotlinx.benchmark.integration
+
+import org.junit.Test
+
+// Regression tests for #185
+class TransitiveDependenciesResolutionTest : GradleTest() {
+    private fun verifyFor(target: String) {
+        project("transitive-dependencies-resolution", true).let { runner ->
+            runner.runAndSucceed("${target}Benchmark")
+        }
+    }
+
+    @Test
+    fun js() {
+        verifyFor("js")
+    }
+
+    @Test
+    fun native() {
+        verifyFor("native")
+    }
+
+    @Test
+    fun wasmJs() {
+        verifyFor("wasmJs")
+    }
+}

--- a/integration/src/test/resources/templates/es-modules/build.gradle
+++ b/integration/src/test/resources/templates/es-modules/build.gradle
@@ -1,0 +1,21 @@
+kotlin {
+    js("jsEs") {
+        nodejs()
+        useEsModules()
+    }
+    js("jsUmd") {
+        nodejs()
+    }
+    js("jsCommon") {
+        nodejs()
+        useCommonJs()
+    }
+}
+
+benchmark {
+    targets {
+        register("jsEs")
+        register("jsUmd")
+        register("jsCommon")
+    }
+}

--- a/integration/src/test/resources/templates/es-modules/gradle.properties
+++ b/integration/src/test/resources/templates/es-modules/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/es-modules/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/es-modules/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,16 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.math.*
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun benchmark(): Double {
+        return log(sqrt(3.0) * cos(3.0), 2.0)
+    }
+}

--- a/integration/src/test/resources/templates/project-with-resources/build.gradle
+++ b/integration/src/test/resources/templates/project-with-resources/build.gradle
@@ -1,0 +1,24 @@
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.target.HostManager
+
+kotlin {
+    if (HostManager.hostIsLinux) linuxX64('native')
+    if (HostManager.hostIsMingw) mingwX64('native')
+    if (HostManager.host == KonanTarget.MACOS_ARM64.INSTANCE) macosArm64('native')
+    if (HostManager.host == KonanTarget.MACOS_X64.INSTANCE) macosX64('native')
+    js()
+    wasmJs {
+        nodejs()
+    }
+    js() {
+        nodejs()
+    }
+}
+
+benchmark {
+    targets {
+        register("native")
+        register("js")
+        register("wasmJs")
+    }
+}

--- a/integration/src/test/resources/templates/project-with-resources/gradle.properties
+++ b/integration/src/test/resources/templates/project-with-resources/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/project-with-resources/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/project-with-resources/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,16 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.math.*
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun mathBenchmark(): Double {
+        return log(sqrt(3.0) * cos(3.0), 2.0)
+    }
+}

--- a/integration/src/test/resources/templates/project-with-resources/src/commonMain/resources/dummy.file.txt
+++ b/integration/src/test/resources/templates/project-with-resources/src/commonMain/resources/dummy.file.txt
@@ -1,0 +1,1 @@
+I'm here to break your build!

--- a/integration/src/test/resources/templates/transitive-dependencies-resolution/build.gradle
+++ b/integration/src/test/resources/templates/transitive-dependencies-resolution/build.gradle
@@ -1,0 +1,41 @@
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+def parentRepositories = repositories
+
+subprojects {
+    repositories {
+        parentRepositories.forEach {
+            add(it)
+        }
+    }
+}
+
+kotlin {
+    if (HostManager.hostIsLinux) linuxX64('native')
+    if (HostManager.hostIsMingw) mingwX64('native')
+    if (HostManager.host == KonanTarget.MACOS_ARM64.INSTANCE) macosArm64('native')
+    if (HostManager.host == KonanTarget.MACOS_X64.INSTANCE) macosX64('native')
+    wasmJs {
+        nodejs()
+    }
+    js() {
+        nodejs()
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(project(":library"))
+            }
+        }
+    }
+}
+
+benchmark {
+    targets {
+        register("native")
+        register("js")
+        register("wasmJs")
+    }
+}

--- a/integration/src/test/resources/templates/transitive-dependencies-resolution/gradle.properties
+++ b/integration/src/test/resources/templates/transitive-dependencies-resolution/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/transitive-dependencies-resolution/library/build.gradle
+++ b/integration/src/test/resources/templates/transitive-dependencies-resolution/library/build.gradle
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+plugins {
+    id 'org.jetbrains.kotlin.multiplatform'
+}
+
+kotlin {
+    if (HostManager.hostIsLinux) linuxX64('native')
+    if (HostManager.hostIsMingw) mingwX64('native')
+    if (HostManager.host == KonanTarget.MACOS_ARM64.INSTANCE) macosArm64('native')
+    if (HostManager.host == KonanTarget.MACOS_X64.INSTANCE) macosX64('native')
+    wasmJs {
+        nodejs()
+    }
+    js() {
+        nodejs()
+    }
+
+    sourceSets {
+        jsMain {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+        nativeMain {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+        wasmJsMain {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+    }
+}

--- a/integration/src/test/resources/templates/transitive-dependencies-resolution/library/src/commonMain/kotlin/library.kt
+++ b/integration/src/test/resources/templates/transitive-dependencies-resolution/library/src/commonMain/kotlin/library.kt
@@ -1,0 +1,5 @@
+package test
+
+public fun valuableWorkload(): Double {
+    return 42.0
+}

--- a/integration/src/test/resources/templates/transitive-dependencies-resolution/settings.gradle
+++ b/integration/src/test/resources/templates/transitive-dependencies-resolution/settings.gradle
@@ -1,0 +1,1 @@
+include("library")

--- a/integration/src/test/resources/templates/transitive-dependencies-resolution/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/transitive-dependencies-resolution/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,15 @@
+package test
+
+import kotlinx.benchmark.*
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun mathBenchmark(): Double {
+        return valuableWorkload()
+    }
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsEngineExecTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsEngineExecTasks.kt
@@ -8,6 +8,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.util.internal.VersionNumber
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.plugin.mpp.fileExtension
 import org.jetbrains.kotlin.gradle.targets.js.d8.D8Exec
 import org.jetbrains.kotlin.gradle.targets.js.d8.D8RootExtension
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
@@ -55,9 +56,12 @@ private fun Project.getExecutableFile(compilation: KotlinJsIrCompilation): Provi
     val kotlinTarget = compilation.target as KotlinJsIrTarget
     val binary = kotlinTarget.binaries.executable(compilation)
         .first { it.mode == KotlinJsBinaryMode.PRODUCTION } as JsIrBinary
-    val extension = if (kotlinTarget.platformType == KotlinPlatformType.wasm) "mjs" else "js"
     val outputFileName = binary.linkTask.flatMap { task ->
-        task.compilerOptions.moduleName.map { "$it.$extension" }
+        task.compilerOptions.moduleName.flatMap { modName ->
+            compilation.fileExtension.map { extension ->
+                "$modName.$extension"
+            }
+        }
     }
     val destinationDir = binary.linkSyncTask.flatMap { it.destinationDirectory }
     val executableFile = destinationDir.zip(outputFileName) { dir, fileName -> dir.resolve(fileName) }

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
@@ -5,6 +5,7 @@ import org.gradle.api.*
 import org.jetbrains.kotlin.gradle.dsl.JsModuleKind
 import org.jetbrains.kotlin.gradle.targets.js.dsl.*
 import org.jetbrains.kotlin.gradle.targets.js.ir.*
+import org.jetbrains.kotlin.serialization.js.ModuleKind
 
 @KotlinxBenchmarkPluginInternalApi
 fun Project.processJsCompilation(target: JsBenchmarkTarget) {
@@ -56,7 +57,8 @@ private fun Project.createJsBenchmarkCompileTask(target: JsBenchmarkTarget): Kot
 
                 compilerOptions {
                     sourceMap.set(true)
-                    moduleKind.set(JsModuleKind.MODULE_UMD)
+                    //moduleKind.set(JsModuleKind.MODULE_UMD)
+                    moduleKind.set(JsModuleKind.fromKind(compilation.kotlinOptions.moduleKind ?: JsModuleKind.MODULE_UMD.kind))
                 }
             }
         }

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
@@ -74,8 +74,8 @@ private fun Project.createJsBenchmarkGenerateSourceTask(
         description = "Generate JS source files for '${target.name}'"
         title = target.name
         useBenchmarkJs = target.jsBenchmarksExecutor == JsBenchmarksExecutor.BenchmarkJs
-        inputClassesDirs = compilationOutput.output.allOutputs
-        inputDependencies = compilationOutput.compileDependencyFiles
+        inputClassesDirs = compilationOutput.output.classesDirs
+        inputDependencies = compilationOutput.runtimeDependencyFiles
         outputResourcesDir = file("$benchmarkBuildDir/resources")
         outputSourcesDir = file("$benchmarkBuildDir/sources")
     }

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsMultiplatformTasks.kt
@@ -57,8 +57,9 @@ private fun Project.createJsBenchmarkCompileTask(target: JsBenchmarkTarget): Kot
 
                 compilerOptions {
                     sourceMap.set(true)
-                    //moduleKind.set(JsModuleKind.MODULE_UMD)
-                    moduleKind.set(JsModuleKind.fromKind(compilation.kotlinOptions.moduleKind ?: JsModuleKind.MODULE_UMD.kind))
+                    compilation.kotlinOptions.moduleKind?.let {
+                        moduleKind.set(JsModuleKind.fromKind(it))
+                    }
                 }
             }
         }

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -43,7 +43,7 @@ private fun Project.createNativeBenchmarkGenerateSourceTask(target: NativeBenchm
         val compilation = target.compilation
         this.nativeTarget = compilation.target.konanTarget.name
         title = target.name
-        inputClassesDirs = compilation.output.allOutputs
+        inputClassesDirs = compilation.output.classesDirs
 
         val nativeKlibDependencies = project.configurations.getByName(compilation.defaultSourceSet.implementationMetadataConfigurationName)
         inputDependencies = compilation.compileDependencyFiles + nativeKlibDependencies

--- a/plugin/main/src/kotlinx/benchmark/gradle/WasmMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/WasmMultiplatformTasks.kt
@@ -58,8 +58,8 @@ private fun Project.createWasmBenchmarkGenerateSourceTask(
         group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP
         description = "Generate Wasm source files for '${target.name}'"
         title = target.name
-        inputClassesDirs = compilationOutput.output.allOutputs
-        inputDependencies = compilationOutput.compileDependencyFiles
+        inputClassesDirs = compilationOutput.output.classesDirs
+        inputDependencies = compilationOutput.runtimeDependencyFiles
         outputResourcesDir = file("$benchmarkBuildDir/resources")
         outputSourcesDir = file("$benchmarkBuildDir/sources")
     }

--- a/runtime/jsMain/src/kotlinx/benchmark/NodeJsEngineSupport.kt
+++ b/runtime/jsMain/src/kotlinx/benchmark/NodeJsEngineSupport.kt
@@ -3,14 +3,19 @@ package kotlinx.benchmark
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
-internal external fun require(module: String): dynamic
+@JsModule("fs")
+@JsNonModule
+private external object NodeFileSystem {
+    fun writeFileSync(path: String, data: String)
+    fun readFileSync(path: String, options: String): String
+}
 
 internal object NodeJsEngineSupport : JsEngineSupport() {
     override fun writeFile(path: String, text: String) =
-        require("fs").writeFileSync(path, text)
+        NodeFileSystem.writeFileSync(path, text)
 
     override fun readFile(path: String): String =
-        require("fs").readFileSync(path, "utf8") as String
+        NodeFileSystem.readFileSync(path, "utf8")
 
     override fun arguments(): Array<out String> {
         val arguments = js("process.argv.slice(2).join(' ')") as String

--- a/runtime/jsMain/src/kotlinx/benchmark/js/JsBenchmarkExecutor.kt
+++ b/runtime/jsMain/src/kotlinx/benchmark/js/JsBenchmarkExecutor.kt
@@ -4,6 +4,10 @@ import kotlinx.benchmark.*
 import kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi
 import kotlin.js.Promise
 
+@JsModule("benchmark")
+@JsNonModule
+private external val benchmarkJs: dynamic
+
 @KotlinxBenchmarkRuntimeInternalApi
 class JsBenchmarkExecutor(name: String, @Suppress("UNUSED_PARAMETER") dummy_args: Array<out String>) :
     SuiteExecutor(name, jsEngineSupport.arguments()[0]) {
@@ -11,8 +15,6 @@ class JsBenchmarkExecutor(name: String, @Suppress("UNUSED_PARAMETER") dummy_args
     init {
         check(!isD8) { "${JsBenchmarkExecutor::class.simpleName} does not support d8 engine" }
     }
-
-    private val benchmarkJs: dynamic = require("benchmark")
 
     override fun run(
         runnerConfiguration: RunnerConfiguration,


### PR DESCRIPTION
Following issues revealed in #185 were addressed:
- dependency resolution problem was fixed so now there's no need to explicitly specify all transitive dependencies;
- having files in a resource directory no longer fail compilation;
- benchmarks compilation now inherit module kind from the main compilation.

Closes #185