### PR TITLE
Update kotlinx.team.infra plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 kotlin = "2.0.20"
 kotlin-for-gradle-plugin = "2.0.20" # Kotlin 2.1 removes support for the used language version / api version: KT-60521
 kotlinx-binaryCompatibilityValidator = "0.16.2"
-kotlinx-teamInfra = "0.4.0-dev-81"
+kotlinx-teamInfra = "0.4.0-dev-85"
 squareup-kotlinpoet = "1.3.0"
 jmh = "1.21"
 gradle-pluginPublish = "0.21.0"


### PR DESCRIPTION
Update kotlinx.team.infra to a version that no longer provides native targets and source-set setup functionality that is incompatible with KGP 2.2+.