### PR TITLE
Check if benchmark names are legal Java names on JVM

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/BenchmarkFunctionNameValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/BenchmarkFunctionNameValidationTest.kt
@@ -1,0 +1,26 @@
+package kotlinx.benchmark.integration
+
+import kotlin.test.*
+
+class BenchmarkFunctionNameValidationTest : GradleTest() {
+    @Test
+    fun jvmNamesValidations() {
+        project("funny-names").apply {
+            runAndFail("jvmBenchmarkCompile") {
+                assertOutputContains("One or more benchmark functions are invalid and could not be processed by JMH. See logs for details.")
+                assertOutputDoesNotContain("Group name should be the legal Java identifier")
+
+                assertOutputContains("""Benchmark function name is a reserved Java keyword and cannot be used: "test.CommonBenchmark.assert" (declared as "test.CommonBenchmark.assert")""")
+
+                assertOutputContains("""Benchmark function name is not a valid Java identifier: "test.BenchmarkBase.-illegal base name" (declared as "test.BenchmarkBase.base")""")
+                val firstOccurrence = output.indexOf(""""test.BenchmarkBase.-illegal base name"""")
+                assertEquals(-1, output.indexOf(""""test.BenchmarkBase.-illegal base name"""", firstOccurrence + 1),
+                    "\"test.BenchmarkBase.-illegal base name\" is expected to be reported only once")
+
+                assertOutputContains("""Benchmark function name is not a valid Java identifier: "test.CommonBenchmark.wrapString-gu_FwkY" (declared as "test.CommonBenchmark.wrapString")""")
+                assertOutputContains("""Benchmark function name is not a valid Java identifier: "test.CommonBenchmark.-explicitlyRenamed" (declared as "test.CommonBenchmark.explicitlyRenamed")""")
+                assertOutputContains("""Benchmark function name is not a valid Java identifier: "test.CommonBenchmark.backticked name" (declared as "test.CommonBenchmark.backticked name")""")
+            }
+        }
+    }
+}

--- a/integration/src/test/resources/templates/funny-names/build.gradle
+++ b/integration/src/test/resources/templates/funny-names/build.gradle
@@ -1,0 +1,9 @@
+kotlin {
+    jvm { }
+}
+
+benchmark {
+    targets {
+        register("jvm")
+    }
+}

--- a/integration/src/test/resources/templates/funny-names/gradle.properties
+++ b/integration/src/test/resources/templates/funny-names/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/funny-names/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/funny-names/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,40 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.jvm.*
+
+@JvmInline
+value class StringWrapper(val value: String)
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark // will be wrapString-something on JVM
+    fun wrapString() = StringWrapper("Hello World!")
+
+    @Benchmark
+    @JvmName("-explicitlyRenamed")
+    fun explicitlyRenamed() = 0
+
+    @Benchmark
+    fun `backticked name`() = 0
+
+    @Benchmark
+    fun `assert`() = 0
+}
+
+abstract class BenchmarkBase {
+    @Benchmark
+    @JvmName("-illegal base name")
+    fun base() = 0
+}
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class ConcreteBenchmark : BenchmarkBase()


### PR DESCRIPTION
It seems like there's no so much we can do with invalid Java identifiers being used as function names at the time Kotlin code is already compiled and is about to be processed to generate JMH benchmarks. So instead of trying to work it around, let's report the problem and let users to fix it themselves.

Closes #272