### PR TITLE
Use platform agnostic env variable with the JDK

### DIFF
--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -12,7 +12,7 @@ const val releaseVersionParameter = "releaseVersion"
 const val libraryStagingRepoDescription = "kotlinx-benchmark"
 
 val platforms = Platform.values()
-const val jdk = "JDK_21_0"
+const val jdk = "JDK_17_0"
 
 enum class Platform {
     Windows, Linux, MacOS;

--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -12,7 +12,7 @@ const val releaseVersionParameter = "releaseVersion"
 const val libraryStagingRepoDescription = "kotlinx-benchmark"
 
 val platforms = Platform.values()
-const val jdk = "JDK_21"
+const val jdk = "JDK_21_0"
 
 enum class Platform {
     Windows, Linux, MacOS;

--- a/.teamcity/utils.kt
+++ b/.teamcity/utils.kt
@@ -12,17 +12,12 @@ const val releaseVersionParameter = "releaseVersion"
 const val libraryStagingRepoDescription = "kotlinx-benchmark"
 
 val platforms = Platform.values()
-const val jdk = "JDK_18_x64"
+const val jdk = "JDK_21"
 
 enum class Platform {
     Windows, Linux, MacOS;
 }
 
-fun Platform.nativeTaskPrefix(): String = when(this) {
-    Platform.Windows -> "mingwX64"
-    Platform.Linux -> "linuxX64"
-    Platform.MacOS -> "macosX64"
-}
 fun Platform.buildTypeName(): String = when (this) {
     Platform.Windows, Platform.Linux -> name
     Platform.MacOS -> "Mac OS X"


### PR DESCRIPTION
Existing settings result in using amd64-JDK on arm64 macOS agents (via rosetta).