### PR TITLE
Speedup integration testing pipeline

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -74,9 +74,10 @@ benchmark {
 ```
 
 ### Kotlin/JVM
-| Option                                      | Description                                                | Possible Values                        | Default Value  |
-|---------------------------------------------|------------------------------------------------------------|----------------------------------------|----------------|
-| `advanced("jvmForks", value)`               | Specifies the number of times the harness should fork.     | Non-negative Integer, `"definedByJmh"` | `1`            |
+| Option                                      | Description                                                                | Possible Values                        | Default Value |
+|---------------------------------------------|----------------------------------------------------------------------------|----------------------------------------|---------------|
+| `advanced("jvmForks", value)`               | Specifies the number of times the harness should fork.                     | Non-negative Integer, `"definedByJmh"` | `1`           |
+| `advanced("jmhIgnoreLock", value)`          | Sets a value of the `jmh.ignoreLock` property during benchmarks execution. | `true`, `false`                        | unset         |
 
 **Notes on "jvmForks":**
 - **0** - "no fork", i.e., no subprocesses are forked to run benchmarks.

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -38,4 +38,9 @@ tasks.test {
     }
     systemProperty("minSupportedGradleVersion", libs.versions.minSupportedGradle.get())
     systemProperty("minSupportedKotlinVersion", libs.versions.minSupportedKotlin.get())
+
+    val forks = project.providers.gradleProperty("testing.max.forks").orNull?.toInt()
+        ?: Runtime.getRuntime().availableProcessors()
+
+    maxParallelForks = forks
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -40,7 +40,7 @@ tasks.test {
     systemProperty("minSupportedKotlinVersion", libs.versions.minSupportedKotlin.get())
 
     val forks = project.providers.gradleProperty("testing.max.forks").orNull?.toInt()
-        ?: Runtime.getRuntime().availableProcessors()
+        ?: (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
 
     maxParallelForks = forks
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/AnnotationsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/AnnotationsValidationTest.kt
@@ -2,11 +2,11 @@ package kotlinx.benchmark.integration
 
 import kotlin.test.*
 
-class AnnotationsValidationTest : GradleTest() {
+abstract class AnnotationsValidationTest : GradleTest() {
 
-    private val platformBenchmarkTask = "nativeBenchmark"
+    protected val platformBenchmarkTask = "nativeBenchmark"
 
-    private fun executeBenchmark(
+    protected fun executeBenchmark(
         benchmarkFunction: String? = null,
         setupFunction: String? = null,
         teardownFunction: String? = null,
@@ -26,7 +26,7 @@ class AnnotationsValidationTest : GradleTest() {
         runJvmBenchmark(runner, jvmSpecificError)
     }
 
-    private fun runPlatformBenchmark(runner: Runner, error: String?) {
+    protected fun runPlatformBenchmark(runner: Runner, error: String?) {
         if (error != null) {
             runner.runAndFail(platformBenchmarkTask) {
                 assertOutputContains(error)
@@ -38,7 +38,7 @@ class AnnotationsValidationTest : GradleTest() {
         }
     }
 
-    private fun runJvmBenchmark(runner: Runner, jvmSpecificError: String?) {
+    protected fun runJvmBenchmark(runner: Runner, jvmSpecificError: String?) {
         if (jvmSpecificError != null) {
             runner.runAndFail("jvmBenchmark") {
                 assertOutputContains(jvmSpecificError)
@@ -49,7 +49,9 @@ class AnnotationsValidationTest : GradleTest() {
             }
         }
     }
+}
 
+class ParamAnnotationsValidationTest : AnnotationsValidationTest() {
     // @Param
 
     @Test
@@ -142,7 +144,9 @@ class AnnotationsValidationTest : GradleTest() {
             jvmSpecificError = "@Param can only be placed over the annotation-compatible types: primitives, primitive wrappers, Strings, or enums."
         )
     }
+}
 
+class BenchmarkAnnotationsValidationTest : AnnotationsValidationTest() {
     // @Benchmark
 
     @Test
@@ -204,7 +208,9 @@ class AnnotationsValidationTest : GradleTest() {
             jvmSpecificError = "Method parameters should be either @State classes"
         )
     }
+}
 
+class SetupAnnotationsValidationTest : AnnotationsValidationTest() {
     // @Setup
 
     @Test
@@ -271,7 +277,9 @@ class AnnotationsValidationTest : GradleTest() {
             jvmSpecificError = "Method parameters should be either @State classes"
         )
     }
+}
 
+class TearDownAnnotationsValidationTest : AnnotationsValidationTest() {
     // TearDown
 
     @Test
@@ -338,7 +346,9 @@ class AnnotationsValidationTest : GradleTest() {
             jvmSpecificError = "Method parameters should be either @State classes"
         )
     }
+}
 
+class MixedAnnotationsValidationTest : AnnotationsValidationTest() {
     // Mix
 
     @Test

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ConfigurationCacheTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ConfigurationCacheTest.kt
@@ -37,7 +37,7 @@ class ConfigurationCacheTest : GradleTest() {
     fun testConfigurationCacheNative() = runConfigurationCacheTest(
         "kotlin-multiplatform",
         listOf(":nativeBenchmark"),
-        listOf(":compileKotlinNative", ":nativeBenchmarkGenerate", ":compileNativeBenchmarkKotlinNative", ":linkNativeBenchmarkReleaseExecutableNative")
+        listOf(":compileKotlinNative", ":nativeBenchmarkGenerate", ":compileNativeBenchmarkKotlinNative", ":linkNativeBenchmarkDebugExecutableNative")
     )
 
     @Test

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ConfigurationCacheTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ConfigurationCacheTest.kt
@@ -12,6 +12,7 @@ class ConfigurationCacheTest : GradleTest() {
                 iterations = 1
                 iterationTime = 100
                 iterationTimeUnit = "ms"
+                advanced("jmhIgnoreLock", true)
             }
         }
 

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsOverrideAnnotationsTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsOverrideAnnotationsTest.kt
@@ -91,7 +91,7 @@ class OptionsOverrideAnnotationsTest : GradleTest() {
     @Test
     fun testOutputTimeUnit() {
         val expectedOutputTimeUnit = "ns"
-        val expectedCount = /*warmups*/3 + /*iterations*/5 + /*Success:*/1 + /*summary*/1
+        val expectedCount = /*warmups*/2 + /*iterations*/1 + /*Success:*/1 + /*summary*/1
 
         testConfiguration(
             setupBlock = {
@@ -110,7 +110,7 @@ class OptionsOverrideAnnotationsTest : GradleTest() {
     @Test
     fun testMode() {
         val expectedMode = "avgt"
-        val expectedCount = /*warmups*/3 + /*iterations*/5 + /*Success:*/1 + /*summary*/1
+        val expectedCount = /*warmups*/2 + /*iterations*/1 + /*Success:*/1 + /*summary*/1
 
         testConfiguration(
             setupBlock = {

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/OptionsValidationTest.kt
@@ -240,6 +240,13 @@ class OptionsValidationTest : GradleTest() {
                 iterationTimeUnit = "ms"
                 advanced("jsUseBridge", "x")
             }
+
+            configuration("invalidJmhIgnoreLock") {
+                iterations = 1
+                iterationTime = 100
+                iterationTimeUnit = "ms"
+                advanced("jmhIgnoreLock", "x")
+            }
         }
 
         runner.runAndFail("blankAdvancedConfigNameBenchmark") {
@@ -259,6 +266,9 @@ class OptionsValidationTest : GradleTest() {
         }
         runner.runAndFail("invalidJsUseBridgeBenchmark") {
             assertOutputContains("Invalid value for 'jsUseBridge': 'x'. Expected a Boolean value.")
+        }
+        runner.runAndFail("invalidJmhIgnoreLock") {
+            assertOutputContains("Invalid value for 'jmhIgnoreLock': 'x'. Expected a Boolean value.")
         }
     }
 }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ReportFormatTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ReportFormatTest.kt
@@ -17,6 +17,7 @@ class ReportFormatTest : GradleTest() {
                     iterationTime = 100
                     iterationTimeUnit = "ms"
                     reportFormat = format
+                    advanced("jmhIgnoreLock", true)
                 }
             }
         }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/SourceSetAsBenchmarkTargetTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/SourceSetAsBenchmarkTargetTest.kt
@@ -16,6 +16,7 @@ class SourceSetAsBenchmarkTargetTest : GradleTest() {
                     iterationTime = 100
                     iterationTimeUnit = "ms"
                     reportFormat = "csv"
+                    advanced("jmhIgnoreLock", true)
                 }
             }
 

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/SuiteSourceGeneratorTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/SuiteSourceGeneratorTest.kt
@@ -28,7 +28,7 @@ class SuiteSourceGeneratorTest : GradleTest() {
                 }
             },
             checkBlock = {
-                val parameters = "iterations = 12, warmups = 5, iterationTime = IterationTime\\(200, BenchmarkTimeUnit.MILLISECONDS\\)"
+                val parameters = "iterations = 12, warmups = 2, iterationTime = IterationTime\\(200, BenchmarkTimeUnit.MILLISECONDS\\)"
                 assertGeneratedDescriptorContainsCode(parameters)
             }
         )
@@ -44,7 +44,7 @@ class SuiteSourceGeneratorTest : GradleTest() {
             },
             checkBlock = {
                 // time and timeUnit of @Warmup are ignored: https://github.com/Kotlin/kotlinx-benchmark/issues/74
-                val parameters = "iterations = 3, warmups = 12, iterationTime = IterationTime\\(1, BenchmarkTimeUnit.SECONDS\\)"
+                val parameters = "iterations = 1, warmups = 12, iterationTime = IterationTime\\(1, BenchmarkTimeUnit.SECONDS\\)"
                 assertGeneratedDescriptorContainsCode(parameters)
             }
         )

--- a/integration/src/test/resources/templates/annotations-validation/build.gradle
+++ b/integration/src/test/resources/templates/annotations-validation/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
@@ -17,7 +18,10 @@ benchmark {
         register("jvm")
         register("js")
         register("wasmJs")
-        register("native")
+        register("native") {
+            // don't optimize binaries to speedup test execution
+            buildType = NativeBuildType.DEBUG
+        }
     }
 
     configurations {

--- a/integration/src/test/resources/templates/annotations-validation/build.gradle
+++ b/integration/src/test/resources/templates/annotations-validation/build.gradle
@@ -19,4 +19,10 @@ benchmark {
         register("wasmJs")
         register("native")
     }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
 }

--- a/integration/src/test/resources/templates/annotations-validation/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/annotations-validation/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,8 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Measurement(iterations = 1, time = 1500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Warmup(iterations = 1, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {

--- a/integration/src/test/resources/templates/config-options/build.gradle
+++ b/integration/src/test/resources/templates/config-options/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
@@ -17,7 +18,10 @@ benchmark {
         register("jvm")
         register("js")
         register("wasmJs")
-        register("native")
+        register("native") {
+            // don't optimize binaries to speedup test execution
+            buildType = NativeBuildType.DEBUG
+        }
     }
 
     configurations {

--- a/integration/src/test/resources/templates/config-options/build.gradle
+++ b/integration/src/test/resources/templates/config-options/build.gradle
@@ -19,4 +19,10 @@ benchmark {
         register("wasmJs")
         register("native")
     }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
 }

--- a/integration/src/test/resources/templates/config-options/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/config-options/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,8 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {

--- a/integration/src/test/resources/templates/invalid-target/wasm-nodejs/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/invalid-target/wasm-nodejs/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,7 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {

--- a/integration/src/test/resources/templates/kmp-with-toolchain/higher-version-than-in-gradle/build.gradle
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/higher-version-than-in-gradle/build.gradle
@@ -6,4 +6,10 @@ benchmark {
     targets {
         register("jvm")
     }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
 }

--- a/integration/src/test/resources/templates/kmp-with-toolchain/min-supported-version/build.gradle
+++ b/integration/src/test/resources/templates/kmp-with-toolchain/min-supported-version/build.gradle
@@ -6,4 +6,10 @@ benchmark {
     targets {
         register("jvm")
     }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
 }

--- a/integration/src/test/resources/templates/kotlin-multiplatform-separate-source-set/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-multiplatform-separate-source-set/build.gradle
@@ -13,4 +13,10 @@ benchmark {
         register("jvmCustom")
         register("jsCustom")
     }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
 }

--- a/integration/src/test/resources/templates/kotlin-multiplatform-separate-source-set/src/jsCustom/kotlin/JsCustomBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform-separate-source-set/src/jsCustom/kotlin/JsCustomBenchmark.kt
@@ -4,8 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 2, time = 100, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
-@Measurement(iterations = 3, time = 200, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Warmup(iterations = 1, time = 100, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Measurement(iterations = 1, time = 200, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 open class JsCustomBenchmark {
     @Benchmark

--- a/integration/src/test/resources/templates/kotlin-multiplatform-separate-source-set/src/jvmCustom/kotlin/JvmCustomBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform-separate-source-set/src/jvmCustom/kotlin/JvmCustomBenchmark.kt
@@ -4,8 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 2, time = 100, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
-@Measurement(iterations = 3, time = 200, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Warmup(iterations = 1, time = 100, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Measurement(iterations = 1, time = 200, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 open class JvmCustomBenchmark {
     @Benchmark

--- a/integration/src/test/resources/templates/kotlin-multiplatform/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
@@ -17,7 +18,10 @@ benchmark {
         register("jvm")
         register("js")
         register("wasmJs")
-        register("native")
+        register("native") {
+            // don't optimize binaries to speedup test execution
+            buildType = NativeBuildType.DEBUG
+        }
     }
 
     configurations {

--- a/integration/src/test/resources/templates/kotlin-multiplatform/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/build.gradle
@@ -19,4 +19,10 @@ benchmark {
         register("wasmJs")
         register("native")
     }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
 }

--- a/integration/src/test/resources/templates/kotlin-multiplatform/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,7 +4,7 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {

--- a/integration/src/test/resources/templates/kotlin-multiplatform/src/jsMain/kotlin/RootBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/src/jsMain/kotlin/RootBenchmark.kt
@@ -2,7 +2,7 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class RootBenchmark {

--- a/integration/src/test/resources/templates/kotlin-multiplatform/src/nativeMain/kotlin/RootBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/src/nativeMain/kotlin/RootBenchmark.kt
@@ -2,7 +2,7 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class RootBenchmark {

--- a/integration/src/test/resources/templates/kotlin-multiplatform/src/wasmJsMain/kotlin/RootBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform/src/wasmJsMain/kotlin/RootBenchmark.kt
@@ -2,7 +2,7 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class RootBenchmark {

--- a/integration/src/test/resources/templates/kotlin-native/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-native/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,7 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {

--- a/integration/src/test/resources/templates/kotlin-native/src/nativeMain/kotlin/DebugBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-native/src/nativeMain/kotlin/DebugBenchmark.kt
@@ -4,7 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.native.Platform
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class DebugBenchmark {

--- a/integration/src/test/resources/templates/project-with-resources/build.gradle
+++ b/integration/src/test/resources/templates/project-with-resources/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
@@ -17,7 +18,10 @@ kotlin {
 
 benchmark {
     targets {
-        register("native")
+        register("native") {
+            // don't optimize binaries to speedup test execution
+            buildType = NativeBuildType.DEBUG
+        }
         register("js")
         register("wasmJs")
     }

--- a/integration/src/test/resources/templates/source-generation/build.gradle
+++ b/integration/src/test/resources/templates/source-generation/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
@@ -17,7 +18,10 @@ benchmark {
         register("jvm")
         register("js")
         register("wasmJs")
-        register("native")
+        register("native") {
+            // don't optimize binaries to speedup test execution
+            buildType = NativeBuildType.DEBUG
+        }
     }
 
     configurations {

--- a/integration/src/test/resources/templates/source-generation/build.gradle
+++ b/integration/src/test/resources/templates/source-generation/build.gradle
@@ -19,4 +19,10 @@ benchmark {
         register("wasmJs")
         register("native")
     }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
 }

--- a/integration/src/test/resources/templates/source-generation/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/source-generation/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,8 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
-@Warmup(iterations = 5, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 500, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {

--- a/integration/src/test/resources/templates/transitive-dependencies-resolution/build.gradle
+++ b/integration/src/test/resources/templates/transitive-dependencies-resolution/build.gradle
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
@@ -34,7 +35,10 @@ kotlin {
 
 benchmark {
     targets {
-        register("native")
+        register("native") {
+            // don't optimize binaries to speedup test execution
+            buildType = NativeBuildType.DEBUG
+        }
         register("js")
         register("wasmJs")
     }

--- a/integration/src/test/resources/templates/wasm-gc-non-experimental/wasm-d8/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/wasm-gc-non-experimental/wasm-d8/src/commonMain/kotlin/CommonBenchmark.kt
@@ -4,7 +4,8 @@ import kotlinx.benchmark.*
 import kotlin.math.*
 
 @State(Scope.Benchmark)
-@Measurement(iterations = 3, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.SECONDS)
 @OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
 open class CommonBenchmark {

--- a/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
@@ -7,6 +7,7 @@ import org.gradle.api.file.*
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.compile.*
 import org.gradle.jvm.tasks.*
+import org.jetbrains.kotlin.cli.common.toBooleanLenient
 import java.io.*
 
 @KotlinxBenchmarkPluginInternalApi
@@ -132,6 +133,10 @@ fun Project.createJvmBenchmarkExecTask(
 
         val reportFile = setupReporting(target, config)
         args(writeParameters(target.name, reportFile, traceFormat(), config))
+        when (config.advanced["jmhIgnoreLock"]) {
+            true -> jvmArgs("-Djmh.ignoreLock=true")
+            false -> jvmArgs("-Djmh.ignoreLock=false")
+        }
         javaLauncher.set(javaLauncherProvider())
     }
 }

--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -241,6 +241,10 @@ private fun validateConfig(config: BenchmarkConfiguration) {
                 }
             }
 
+            "jmhIgnoreLock" -> require(value is Boolean) {
+                "Invalid value for 'jmhIgnoreLock': '$value'. Expected a Boolean value."
+            }
+
             "jsUseBridge" -> require(value is Boolean) {
                 "Invalid value for 'jsUseBridge': '$value'. Expected a Boolean value."
             }


### PR DESCRIPTION
Speedup integration tests execution by:
- enabling parallel test suite execution (also added an option to ignore JMH lock file, otherwise benchmarks won't run concurrently);
- split the biggest suite into several classes to exploit parallel execution;
- reduced iteration times for benchmarks;
- switched to debug builds for test benchmarks to reduce compilation times.

As a result, on Windows (which is the slowest platform w.r.t. tests execution) build times were reduced by approximately 15 minutes.