### PR TITLE
Exclude manifest and module-info when creating an uber-jar

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/JarFileTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/JarFileTest.kt
@@ -1,0 +1,13 @@
+package kotlinx.benchmark.integration
+
+import kotlin.test.Test
+
+class JarFileTest : GradleTest() {
+    @Test
+    fun testFilesFiltration() {
+        val runner = project("jar-test", true) {}
+        runner.runAndSucceed("jvmBenchmarkJar") {
+            assertOutputDoesNotContain("Encountered duplicate path")
+        }
+    }
+}

--- a/integration/src/test/resources/templates/jar-test/build.gradle
+++ b/integration/src/test/resources/templates/jar-test/build.gradle
@@ -1,0 +1,18 @@
+kotlin {
+    jvm { }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-test")
+                implementation("org.jetbrains.kotlin:kotlin-reflect")
+            }
+        }
+    }
+}
+
+benchmark {
+    targets {
+        register("jvm")
+    }
+}

--- a/integration/src/test/resources/templates/jar-test/gradle.properties
+++ b/integration/src/test/resources/templates/jar-test/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/jar-test/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/jar-test/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,16 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.math.*
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun mathBenchmark(): Double {
+        return log(sqrt(3.0) * cos(3.0), 2.0)
+    }
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JvmTasks.kt
@@ -35,22 +35,14 @@ fun Project.createJvmBenchmarkCompileTask(target: JvmBenchmarkTarget, compileCla
         dependsOn("${target.name}${BenchmarksPlugin.BENCHMARK_COMPILE_SUFFIX}")
         archiveClassifier.set("JMH")
         manifest.attributes["Main-Class"] = "org.openjdk.jmh.Main"
-
+        exclude("META-INF/**/module-info.class", "META-INF/**/MANIFEST.MF")
         duplicatesStrategy = DuplicatesStrategy.WARN
 
         from(project.provider {
             compileClasspath.map {
                 when {
                     it.isDirectory -> it
-                    it.exists() -> zipTree(it).let { tree ->
-                        if (it.name.startsWith("kotlin-stdlib-jdk")) {
-                            tree.filter { file ->
-                                !(file.toString().contains("META-INF") && file.name in listOf("module-info.class", "MANIFEST.MF"))
-                            }
-                        } else {
-                            tree
-                        }
-                    }
+                    it.exists() -> zipTree(it)
                     else -> files()
                 }
             }


### PR DESCRIPTION
Closes #314