### PR TITLE
Remove scoped resolvable metadata configuration from NativeSourceGeneratorTask

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -44,9 +44,7 @@ private fun Project.createNativeBenchmarkGenerateSourceTask(target: NativeBenchm
         this.nativeTarget = compilation.target.konanTarget.name
         title = target.name
         inputClassesDirs = compilation.output.classesDirs
-
-        val nativeKlibDependencies = project.configurations.getByName(compilation.defaultSourceSet.implementationMetadataConfigurationName)
-        inputDependencies = compilation.compileDependencyFiles + nativeKlibDependencies
+        inputDependencies = compilation.compileDependencyFiles
 
         outputResourcesDir = file("$benchmarkBuildDir/resources")
         outputSourcesDir = file("$benchmarkBuildDir/sources")


### PR DESCRIPTION
We are removing these configurations in https://youtrack.jetbrains.com/issue/KT-61127 / #323 

This code shouldn't be doing anything useful right now because the resolved opaque metadata jars will be filtered out in NativeSourceGeneratorWorker