### PR TITLE
Make Gradle plugin isolation compatible

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
@@ -71,8 +71,8 @@ constructor(
     extension: BenchmarksExtension,
     name: String
 ) : BenchmarkTarget(extension, name) {
-    var jmhVersion: String = (extension.project.findProperty("benchmarks_jmh_version") as? String)
-        ?: BenchmarksPluginConstants.DEFAULT_JMH_VERSION
+    var jmhVersion: String = extension.project.providers.gradleProperty("benchmarks_jmh_version")
+        .orElse(BenchmarksPluginConstants.DEFAULT_JMH_VERSION).get()
 }
 
 class JavaBenchmarkTarget


### PR DESCRIPTION
project.findProperty is not Gradle project isolation compatible (https://docs.gradle.org/current/userguide/isolated_projects.html) because it attempts to read properties from parent projects, thus violating project isolation.

Instead, moving to project.providers.gradleProperty that does not have this behavior.

Fixes https://github.com/Kotlin/kotlinx-benchmark/issues/258