### PR TITLE
Update the name of k/wasm target in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ To run benchmarks in Kotlin/Wasm:
     ```kotlin
     // build.gradle.kts
     kotlin {
-        wasm { 
+        wasmJs { 
             nodejs() 
         }
     }


### PR DESCRIPTION
`wasm` -> `wasmJs`

When following README.md it's convenient when the snippets are up-to-date.

___

Btw, it might be even more convenient if the plugin would show a warning or even an error when a registered target doesn't exist. 