### PR TITLE
Gradle plugin: change kotlin-reflect from implementation to compileOnly

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -105,7 +105,7 @@ kotlin {
 }
 
 dependencies {
-    implementation(libs.kotlin.reflect)
+    compileOnly(libs.kotlin.reflect)
 
     implementation(libs.squareup.kotlinpoet)
 


### PR DESCRIPTION
The only usage of Kotlin Reflect is inside a Worker[1], so the classpath is isolated. This means the Kotlin Reflect dependency can be changed from `implementation` to `compileOnly`.

To avoid clashes with Gradle's embedded Kotlin, and with other plugins, Gradle plugins should avoid using unnecessary dependencies.

Continuation of #229

[1] https://github.com/Kotlin/kotlinx-benchmark/blob/e9becb5101be4e458e1cfcd07936571f85bcb569/plugin/main/src/kotlinx/benchmark/gradle/JmhBytecodeGeneratorWorker.kt#L187