### PR TITLE
Add an integration test for Blackhole injection / use

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/BlackholeInjectionTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/BlackholeInjectionTest.kt
@@ -1,0 +1,21 @@
+package kotlinx.benchmark.integration
+
+import kotlin.test.Test
+
+class BlackholeInjectionTest : GradleTest()  {
+    private fun runForTarget(target: String) {
+        project("kotlin-multiplatform-with-blackhole")
+            .runAndSucceed("${target}Benchmark")
+    }
+    @Test
+    fun native() = runForTarget("native")
+
+    @Test
+    fun js() = runForTarget("js")
+
+    @Test
+    fun wasmJs() = runForTarget("wasmJs")
+
+    @Test
+    fun jvm() = runForTarget("jvm")
+}

--- a/integration/src/test/resources/templates/kotlin-multiplatform-with-blackhole/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-multiplatform-with-blackhole/build.gradle
@@ -1,0 +1,32 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import org.jetbrains.kotlin.konan.target.HostManager
+
+kotlin {
+    jvm {}
+    js { nodejs() }
+    wasmJs { d8() }
+
+    if (HostManager.hostIsLinux) linuxX64('native')
+    if (HostManager.hostIsMingw) mingwX64('native')
+    if (HostManager.host == KonanTarget.MACOS_X64.INSTANCE) macosX64('native')
+    if (HostManager.host == KonanTarget.MACOS_ARM64.INSTANCE) macosArm64('native')
+}
+
+benchmark {
+    targets {
+        register("jvm")
+        register("js")
+        register("wasmJs")
+        register("native") {
+            // don't optimize binaries to speedup test execution
+            buildType = NativeBuildType.DEBUG
+        }
+    }
+
+    configurations {
+        main {
+            advanced("jmhIgnoreLock", true)
+        }
+    }
+}

--- a/integration/src/test/resources/templates/kotlin-multiplatform-with-blackhole/gradle.properties
+++ b/integration/src/test/resources/templates/kotlin-multiplatform-with-blackhole/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8

--- a/integration/src/test/resources/templates/kotlin-multiplatform-with-blackhole/src/commonMain/kotlin/CommonBenchmark.kt
+++ b/integration/src/test/resources/templates/kotlin-multiplatform-with-blackhole/src/commonMain/kotlin/CommonBenchmark.kt
@@ -1,0 +1,15 @@
+package test
+
+import kotlinx.benchmark.*
+import kotlin.math.*
+
+@State(Scope.Benchmark)
+@Measurement(iterations = 1, time = 100, timeUnit = BenchmarkTimeUnit.MILLISECONDS)
+@OutputTimeUnit(BenchmarkTimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+open class CommonBenchmark {
+    @Benchmark
+    open fun mathBenchmark(bh: Blackhole) {
+        bh.consume(log(sqrt(3.0) * cos(3.0), 2.0))
+    }
+}


### PR DESCRIPTION
Add a test for blackhole injections and its use. There's an issue in recent Kotlin builds that broke this scenario, and we were not able to catch it earlier because there were no test.