### PR TITLE
Fix generation of code with redundant conversion warning in SuiteSourceGenerator 

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/SuiteSourceGenerator.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/SuiteSourceGenerator.kt
@@ -223,7 +223,9 @@ class SuiteSourceGenerator(
 
                     parameterProperties.forEach { property ->
                         val type = property.type.nameIfStandardType!!
-                        addStatement("instance.${property.name} = params.getValue(\"${property.name}\").to$type()")
+                        // otherwise it will cause `REDUNDANT_CALL_OF_CONVERSION_METHOD` warning in user code (KT-77727)
+                        val conversion = if (type.toString() == STRING.simpleName) "" else ".to$type()"
+                        addStatement("instance.${property.name} = params.getValue(\"${property.name}\")$conversion")
                     }
                 }
 


### PR DESCRIPTION
Because of "[KT-77727](https://youtrack.jetbrains.com/issue/KT-77727) Move some of the extra checkers to the default list" ([related internal discussion](https://jetbrains.slack.com/archives/C06E082M6/p1753979502791609))

Spotted in [cryptography-kotlin](https://github.com/whyoleg/cryptography-kotlin) while updating to Kotlin 2.3.0