### PR TITLE
Replace usage of findProperty with gradle provider API

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/Utils.kt
@@ -288,7 +288,7 @@ fun Project.javaLauncherProvider(): Provider<JavaLauncher> = provider {
 }
 
 internal fun Project.checkJmhVersion(target: JvmBenchmarkTarget) {
-    if (project.findProperty("benchmarks_jmh_version_skip_check")?.toString()?.toBoolean() == true) {
+    if (providers.gradleProperty("benchmarks_jmh_version_skip_check").map { it.toBoolean() }.orElse(false).get()) {
         return
     }
 


### PR DESCRIPTION
This helps remove another issue with Gradle project isolation

https://github.com/Kotlin/kotlinx-benchmark/issues/258