### PR TITLE
Skip ProjectIsolationTest if JDK is older than 17

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ProjectIsolationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ProjectIsolationTest.kt
@@ -1,10 +1,12 @@
 package kotlinx.benchmark.integration
 
+import org.junit.Assume
 import kotlin.test.Test
 
 class ProjectIsolationTest : GradleTest() {
     @Test
     fun testIsolation() {
+        Assume.assumeTrue("The test requires JDK 17 or newer.", Runtime.version().feature() >= 17)
         // Use either 2.3.0, or a Kotlin version used to build tests, if it is a more recent one
         // (which is the case when running tests with Kotlin built from the HEAD).
         val version = KotlinTestVersion.mostRecent(


### PR DESCRIPTION
The test uses Gradle 9.3 which requires JDK 17 or newer to run.

In some configurations we use earlier JDK version to build the project and run tests. To avoid test failures, the test could be simply skipped.