### PR TITLE
Replace deprecated `NodeJsExec#create` with `NodeJsExec#register`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Note: Kotlin version can be overridden by passing `-Pkotlin_version=<version>`
-kotlin = "2.0.20"
+kotlin = "2.1.20"
 kotlin-for-gradle-plugin = "2.0.20" # Kotlin 2.1 removes support for the used language version / api version: KT-60521
 kotlinx-binaryCompatibilityValidator = "0.16.2"
 kotlinx-teamInfra = "0.4.0-dev-85"

--- a/plugin/main/src/kotlinx/benchmark/gradle/JsEngineExecTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/JsEngineExecTasks.kt
@@ -85,7 +85,7 @@ private fun Project.createNodeJsExec(
     target: BenchmarkTarget,
     compilation: KotlinJsIrCompilation,
     taskName: String
-): TaskProvider<NodeJsExec> = NodeJsExec.create(compilation, taskName) {
+): TaskProvider<NodeJsExec> = NodeJsExec.register(compilation, taskName) {
     dependsOn(compilation.runtimeDependencyFiles)
     group = BenchmarksPlugin.BENCHMARKS_TASK_GROUP
     description = "Executes benchmark for '${target.name}' with NodeJS"


### PR DESCRIPTION
`NodeJsExec#create` was deprecated in 2.1.20.
The replacement, `NodeJsExec#register`, was added in the same release, hence the Kotlin version bump.

Because kotlinx-benchmark is used as a test project in Kotlin's release process this change is needed to remove the deprecated function.

Fix #355