### PR TITLE
Document JDK requirements for building project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,9 @@ This project is built with Gradle.
 
 * Run `./gradlew build` to build. It also runs all the tests.
 
+The project requires a JDK that is supported by the version of Gradle defined in [`minSupportedGradle`](gradle/libs.versions.toml).
+Currently, this is JDK 17.
+
 You can import this project into IDEA, but you have to delegate build actions
 to Gradle (in Preferences -> Build, Execution, Deployment -> Build Tools -> Gradle -> Build and run).
 


### PR DESCRIPTION
If you are cloning this repository for the first time and run `./gradlew build` (as mentioned in the README), then the build will crash on newer JDK versions (those above 17).

More specifically, all integration tests will fail with errors that look like this:

```
Could not open cp_settings generic class cache for settings file '/Users/christian.melchior/JetBrains/kotlinx-benchmark/integration/build/temp/junit2537689578524473120/settings.gradle' (/Users/christian.melchior/JetBrains/kotlinx-benchmark/integration/build/tmp/test/work/.gradle-test-kit/caches/8.0/scripts/b6ltsivyc37amugqxzcmvy0ka).
> BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 65
```

Looking into the code, it looks like the problem is in `GradleTest` that configures the JVM toolchain for Integration tests, but it will reuse any existing build caches.  This means that the older toolchain will try to read the project class files built with the newer system JDK and throw the above error.

We might be able to do something clever with a custom `--gradle-user-home` argument in the `Runner`, but it wouldn't affect the top-level project file.

So for now, just documenting which JDK to use seems the best choice.