### PR TITLE
Use JDK17 toolchain to build the project

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,13 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     `kotlin-dsl`
+}
+
+kotlin {
+    jvmToolchain(17)
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+}
+tasks.withType(JavaCompile::class) {
+    options.release = 8
 }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
     testImplementation(kotlin("test-junit"))
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 tasks.test {
     dependsOn(plugin.task(":publishToBuildLocal"))
     dependsOn(runtime.tasks.getByName("publishToBuildLocal"))

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ProjectIsolationTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ProjectIsolationTest.kt
@@ -1,12 +1,10 @@
 package kotlinx.benchmark.integration
 
-import org.junit.Assume
 import kotlin.test.Test
 
 class ProjectIsolationTest : GradleTest() {
     @Test
     fun testIsolation() {
-        Assume.assumeTrue("The test requires JDK 17 or newer.", Runtime.version().feature() >= 17)
         // Use either 2.3.0, or a Kotlin version used to build tests, if it is a more recent one
         // (which is the case when running tests with Kotlin built from the HEAD).
         val version = KotlinTestVersion.mostRecent(

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,6 +3,7 @@ import kotlinx.team.infra.InfraExtension
 import org.gradle.plugin.compatibility.compatibility
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 buildscript {
     repositories {
@@ -94,12 +95,14 @@ sourceSets {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 
     @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
     compilerVersion = libs.versions.kotlin.`for`.gradle.plugin.get()
 
     compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+
         optIn.addAll(
                 "kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi",
                 "kotlin.RequiresOptIn",
@@ -207,4 +210,8 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
 
 apiValidation {
     nonPublicMarkers += listOf("kotlinx.benchmark.gradle.internal.KotlinxBenchmarkPluginInternalApi")
+}
+
+tasks.withType(JavaCompile::class).configureEach {
+    options.release.set(8)
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
@@ -15,7 +16,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 
     // According to https://kotlinlang.org/docs/native-target-support.html
 
@@ -50,7 +51,12 @@ kotlin {
     @Suppress("DEPRECATION", "DEPRECATION_ERROR")
     watchosX64()
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
+        }
+    }
+
     js { nodejs() }
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
@@ -113,6 +119,10 @@ kotlin {
             }
         }
     }
+}
+
+tasks.withType(JavaCompile::class).configureEach {
+    options.release.set(8)
 }
 
 if (project.findProperty("publication_repository") == "space") {


### PR DESCRIPTION
Some tests (namely, ProjectIsolationTest) requires JDK 17 to run. Previously, we can't use it due to some issues in one of CI projects, but now we can safely setup the toolchain.

Note that there are still some limitations on the CI side preventing use of newer JDKs.