### PR TITLE
Fix run suite which does not exists

### DIFF
--- a/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
+++ b/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
@@ -17,7 +17,7 @@ fun runBenchmarksBuiltIn(name: String, args: Array<out String>, declareAndExecut
             SingleBenchmarkExecutor(
                 executionName = name,
                 runnerConfiguration = RunnerConfiguration(configPath.readFile()),
-                suiteIndex = arguments[1].toInt(),
+                suiteId = arguments[1],
                 benchmarkId = arguments[2],
             )
         }

--- a/runtime/jsWasmJsSharedMain/src/kotlinx/benchmark/SingleBenchmarkExecutor.kt
+++ b/runtime/jsWasmJsSharedMain/src/kotlinx/benchmark/SingleBenchmarkExecutor.kt
@@ -3,11 +3,11 @@ package kotlinx.benchmark
 internal class SingleBenchmarkExecutor(
     override val executionName: String,
     private val runnerConfiguration: RunnerConfiguration,
-    private val suiteIndex: Int,
+    private val suiteId: String,
     private val benchmarkId: String,
 ) : SuiteExecutorBase(), CommonBenchmarkExtension {
     override fun run() {
-        val suiteToRun = suites[suiteIndex]
+        val suiteToRun = suites.firstOrNull { it.name.replaceSpaceWithPercent() == suiteId } ?: return
         val benchmarkConfiguration = BenchmarkConfiguration(runnerConfiguration, suiteToRun)
 
         runWithParameters(suiteToRun.parameters, runnerConfiguration.params, suiteToRun.defaultParameters) { parameters ->

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmJsExecutorFactory.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmJsExecutorFactory.kt
@@ -56,7 +56,7 @@ internal fun runBenchmarksImpl(name: String, @Suppress("unused") args: Array<out
             SingleBenchmarkExecutor(
                 executionName = name,
                 runnerConfiguration = config,
-                suiteIndex = arguments[1].toInt(),
+                suiteId = arguments[1],
                 benchmarkId = arguments[2],
             )
         }

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmPerProcessExecutors.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmPerProcessExecutors.kt
@@ -21,14 +21,13 @@ internal class SpawnBenchmarkExecutor(
         id: String,
         progress: BenchmarkProgress,
     ): DoubleArray? {
-        val suiteIndex = suites.indexOf(benchmark.suite)
-        check(suiteIndex >= 0)
         val benchmarkId = id.replaceSpaceWithPercent()
+        val suiteId = benchmark.suite.name.replaceSpaceWithPercent()
         val modulePath = nodeJsEngineModulePath()
         val scriptDirectory = engineWorkingDir ?: nodeJsGetDirName(modulePath)
 
         val jsParameters =
-            getJsParameters(engineArguments, modulePath, listOf(configPath, suiteIndex.toString(), benchmarkId))
+            getJsParameters(engineArguments, modulePath, listOf(configPath, suiteId, benchmarkId))
 
         val result = spawnProcessAndGetResult(engineBinaryPath, scriptDirectory, jsParameters)
 

--- a/runtime/wasmWasiMain/src/kotlinx/benchmark/wasm/WasmWasiExecutorFactory.kt
+++ b/runtime/wasmWasiMain/src/kotlinx/benchmark/wasm/WasmWasiExecutorFactory.kt
@@ -23,7 +23,7 @@ fun runBenchmarks(name: String, @Suppress("unused") args: Array<out String>, dec
             SingleBenchmarkExecutor(
                 executionName = name,
                 runnerConfiguration = config,
-                suiteIndex = arguments[3].toInt(),
+                suiteId = arguments[3],
                 benchmarkId = arguments[4],
             )
         }


### PR DESCRIPTION
If someone wants to run a suite which exists on spawn runner but does not exists in runned suites set it should not fail but just be skipped