### PR TITLE
Do not use JSPI in Wasm runtime

### DIFF
--- a/runtime/commonMain/src/kotlinx/benchmark/Utils.kt
+++ b/runtime/commonMain/src/kotlinx/benchmark/Utils.kt
@@ -3,3 +3,37 @@ package kotlinx.benchmark
 internal expect fun String.readFile(): String
 
 internal expect fun String.writeFile(text: String)
+
+internal enum class StartMode {
+    Default,
+    StartAll,
+    RunSingleWithOutputSplitter,
+    RunSingle
+}
+
+internal data class StartArguments(
+    val config: String,
+    val mode: StartMode,
+    val suiteId: String? = null,
+    val benchmarkId: String? = null
+) {
+    companion object {
+        fun parse(arguments: Array<out String>): StartArguments {
+            val config: String = arguments[0]
+            if (arguments.size == 1) return StartArguments(config, StartMode.Default)
+
+            val mode = StartMode.valueOf(arguments[1])
+            if (arguments.size == 2) return StartArguments(config, mode)
+
+            val suiteId = arguments[2]
+            val benchmarkId = arguments[3]
+            return StartArguments(config, mode, suiteId, benchmarkId)
+        }
+    }
+
+    fun toArray(): Array<out String> = when {
+        mode == StartMode.Default -> arrayOf(config)
+        suiteId == null || benchmarkId == null -> arrayOf(config, mode.name)
+        else -> arrayOf(config, mode.name, suiteId, benchmarkId)
+    }
+}

--- a/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
+++ b/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
@@ -6,22 +6,26 @@ import kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi
 @KotlinxBenchmarkRuntimeInternalApi
 fun runBenchmarksBuiltIn(name: String, args: Array<out String>, declareAndExecuteSuites: (SuiteExecutorBase) -> Unit) {
     val arguments = engineSupport.arguments()
-    val configPath = arguments[0]
 
-    val executor = when (arguments.size) {
-        2 -> {
-            check(arguments[1] == "startAll")
+    val executor = when {
+        arguments.any { it == "startAll" } -> {
+            val newArguments = arguments.filterNot { it == "startAll" }.toTypedArray()
+            val configPath = newArguments[0]
             JsBuiltInExecutor(name, configPath)
         }
-        3 -> {
+        arguments.any { it == "runSingle" } -> {
+            val newArguments = arguments.filterNot { it == "runSingle" }.toTypedArray()
+            val configPath = newArguments[0]
+            val config = RunnerConfiguration(configPath.readFile())
             SingleBenchmarkExecutor(
                 executionName = name,
-                runnerConfiguration = RunnerConfiguration(configPath.readFile()),
+                runnerConfiguration = config,
                 suiteId = arguments[1],
                 benchmarkId = arguments[2],
             )
         }
         else -> {
+            val configPath = arguments[0]
             JsBuiltInExecutor(name, configPath)
         }
     }

--- a/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
+++ b/runtime/jsMain/src/kotlinx/benchmark/js/JsBuiltInExecutor.kt
@@ -5,28 +5,23 @@ import kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi
 
 @KotlinxBenchmarkRuntimeInternalApi
 fun runBenchmarksBuiltIn(name: String, args: Array<out String>, declareAndExecuteSuites: (SuiteExecutorBase) -> Unit) {
-    val arguments = engineSupport.arguments()
+    val arguments = StartArguments.parse(engineSupport.arguments())
 
-    val executor = when {
-        arguments.any { it == "startAll" } -> {
-            val newArguments = arguments.filterNot { it == "startAll" }.toTypedArray()
-            val configPath = newArguments[0]
-            JsBuiltInExecutor(name, configPath)
+    val executor = when(arguments.mode) {
+        StartMode.Default, StartMode.StartAll -> {
+            JsBuiltInExecutor(name, arguments.config)
         }
-        arguments.any { it == "runSingle" } -> {
-            val newArguments = arguments.filterNot { it == "runSingle" }.toTypedArray()
-            val configPath = newArguments[0]
-            val config = RunnerConfiguration(configPath.readFile())
+        StartMode.RunSingle -> {
+            val config = RunnerConfiguration(arguments.config.readFile())
             SingleBenchmarkExecutor(
                 executionName = name,
                 runnerConfiguration = config,
-                suiteId = arguments[1],
-                benchmarkId = arguments[2],
+                suiteId = arguments.suiteId ?: error("suiteId must be specified"),
+                benchmarkId = arguments.benchmarkId ?: error("benchmarkId must be specified"),
             )
         }
         else -> {
-            val configPath = arguments[0]
-            JsBuiltInExecutor(name, configPath)
+            error("Unexpected arguments ${arguments.toArray().joinToString(" ")}")
         }
     }
 

--- a/runtime/jsWasmJsSharedMain/src/kotlinx/benchmark/SingleBenchmarkExecutor.kt
+++ b/runtime/jsWasmJsSharedMain/src/kotlinx/benchmark/SingleBenchmarkExecutor.kt
@@ -20,7 +20,7 @@ internal class SingleBenchmarkExecutor(
             @Suppress("UNCHECKED_CAST")
             val result = runBenchmark(benchmarkToRun as BenchmarkDescriptor<Any?>, benchmarkConfiguration, parameters, benchmarkId, progress)
             val stringifiedResult = result?.joinToString(separator = ",") { it.toRawBits().toString() } ?: ""
-            println("<RESULT>$stringifiedResult</RESULT>")
+            println("$resultTag$stringifiedResult$endResultTag")
         }
     }
 }

--- a/runtime/jsWasmJsSharedMain/src/kotlinx/benchmark/Utils.kt
+++ b/runtime/jsWasmJsSharedMain/src/kotlinx/benchmark/Utils.kt
@@ -1,3 +1,6 @@
 package kotlinx.benchmark
 
 internal fun String.replaceSpaceWithPercent() = replace(' ', '%')
+
+internal const val resultTag = "<RESULT>"
+internal const val endResultTag = "<ENDRESULT>"

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/OutputStreamFileWriter.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/OutputStreamFileWriter.kt
@@ -35,7 +35,18 @@ internal class FileStream(val filename: String) : OutputStream() {
     }
 }
 
-internal class ConsoleAndFilesOutputStream : OutputStream() {
+internal object Fd3Stream : OutputStream() {
+    override fun flush() {
+        fs.writeSync(3, buffer.toString())
+        buffer.clear()
+    }
+
+    override fun write(b: Char) {
+        buffer.append(b)
+    }
+}
+
+internal class SplittedOutputStream(private val processResultTags: Boolean) : OutputStream() {
     private var currentStream: OutputStream = ConsoleLinesStream
     private val fileTag = "<FILE:"
     private val endFileTag = "<ENDFILE>"
@@ -51,12 +62,16 @@ internal class ConsoleAndFilesOutputStream : OutputStream() {
         if (tag.startsWith(fileTag)) {
             check(currentStream !is FileStream) { "$endFileTag not found" }
             val fileName = tag.substring(fileTag.length, tag.lastIndex)
-            println(fileName)
             currentStream = FileStream(fileName)
         } else if (tag == endFileTag) {
-            val currentFile = currentStream as? FileStream
-            check(currentFile != null) { "$fileTag not found" }
-            currentFile.flush()
+            check(currentStream is FileStream) { "$fileTag not found" }
+            currentStream.flush()
+            currentStream = ConsoleLinesStream
+        } else if (processResultTags && tag == resultTag) {
+            currentStream = Fd3Stream
+        } else if (processResultTags && tag == endResultTag) {
+            check(currentStream is Fd3Stream) { "$resultTag not found" }
+            currentStream.flush()
             currentStream = ConsoleLinesStream
         } else {
             writeToCurrentStream()

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/SpawnUtils.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/SpawnUtils.kt
@@ -1,9 +1,8 @@
 package kotlinx.benchmark
 
-import kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi
 import kotlin.js.Promise
 
-private fun jsSpawnProcess(
+private fun jsSpawnProcessAsync(
     childProcess: ChildProcess,
     binaryPath: String,
     workingDir: String,
@@ -18,30 +17,18 @@ private fun jsSpawnProcess(
     });
 }""")
 
-internal fun spawnProcessAndGetResult(binaryPath: String, workingDir: String, engineArguments: JsArray<JsString>): String? {
-    var resultValue: String? = null
-    jsSpawnProcess(childProcess, binaryPath, workingDir, engineArguments) {
-        val trimmed = it.trimEnd()
-        val result = Regex("<RESULT>(.*)</RESULT>").find(trimmed)
-        if (result != null) {
-            resultValue = result.groupValues[1]
-        } else {
-            print(trimmed)
-        }
-    }.await()
-    return resultValue?.takeIf { it.isNotEmpty() }
-}
-
-internal fun spawnProcess(binaryPath: String, workingDir: String, engineArguments: JsArray<JsString>) {
-    val stream = ConsoleAndFilesOutputStream()
-    jsSpawnProcess(childProcess, binaryPath, workingDir, engineArguments) {
+internal fun spawnProcessAsyncAndProcessTags(binaryPath: String, workingDir: String, engineArguments: JsArray<JsString>, processResultTags: Boolean) {
+    val stream = SplittedOutputStream(processResultTags)
+    jsSpawnProcessAsync(childProcess, binaryPath, workingDir, engineArguments) {
         val trimmed = it.trimEnd()
         trimmed.forEach(stream::write)
         if (trimmed.length != it.length) {
             stream.flush()
         }
-    }.await()
-    stream.flush()
+    }.then {
+        stream.flush()
+        it
+    }
 }
 
 internal fun getJsParameters(engineArguments: List<String>?, modulePath: String, arguments: List<String>): JsArray<JsString> {
@@ -64,19 +51,12 @@ internal fun getJsParameters(engineArguments: List<String>?, modulePath: String,
     return jsArguments
 }
 
-@JsFun("""(typeof WebAssembly.Suspending === 'undefined')
-    ? () => { throw new Error('The node.js version is outdated. Please use version 25 or higher.'); }
-    : new WebAssembly.Suspending((p) => p)""")
-private external fun <T : JsAny> await(p: Promise<T>): T
-
-private fun <T : JsAny> Promise<T>.await(): T = await(this)
-
-@OptIn(ExperimentalJsExport::class)
-@JsExport
-@KotlinxBenchmarkRuntimeInternalApi
-fun jsPromisingStart(body: JsReference<() -> Unit>): Unit = body.get().invoke()
-
-private fun jsPromiseIntegration(body: JsReference<() -> Unit>): Unit =
-    js("""(typeof WebAssembly.promising === 'undefined') ? wasmExports.jsPromisingStart(body) : WebAssembly.promising(wasmExports.jsPromisingStart)(body)""")
-
-internal fun jsPromiseIntegration(body: () -> Unit) = jsPromiseIntegration(body.toJsReference())
+internal fun jsSpawnProcessWithExtraPipeSyncAndGetResult(
+    childProcess: ChildProcess,
+    binaryPath: String,
+    workingDir: String,
+    engineArguments: JsArray<JsString>,
+): String? = js("""{
+   const process = childProcess.spawnSync(binaryPath, engineArguments, { cwd: workingDir, encoding: 'utf8', stdio: ['inherit', 'inherit', 'inherit', 'pipe'] });
+   return (process.status === 0) ? process.output[3] : null;
+}""")

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/SpawnUtils.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/SpawnUtils.kt
@@ -31,7 +31,7 @@ internal fun spawnProcessAsyncAndProcessTags(binaryPath: String, workingDir: Str
     }
 }
 
-internal fun getJsParameters(engineArguments: List<String>?, modulePath: String, arguments: List<String>): JsArray<JsString> {
+internal fun getJsParameters(engineArguments: List<String>?, modulePath: String, startArguments: StartArguments): JsArray<JsString> {
     val actualEngineArguments = engineArguments ?: listOf("<MODULE>", "<ARGUMENTS>")
 
     val jsArguments = JsArray<JsString>()
@@ -44,7 +44,7 @@ internal fun getJsParameters(engineArguments: List<String>?, modulePath: String,
     actualEngineArguments.forEach { engineArgument ->
         when (engineArgument) {
             "<MODULE>" -> addJsArgument(modulePath)
-            "<ARGUMENTS>" -> arguments.forEach(::addJsArgument)
+            "<ARGUMENTS>" -> startArguments.toArray().forEach(::addJsArgument)
             else -> addJsArgument(engineArgument)
         }
     }

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/Utils.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/Utils.kt
@@ -29,3 +29,5 @@ internal const val LOAD_MODULE_PREFIX =
     "((module) => () => module)(((typeof process !== 'undefined') && (process.release.name === 'node')) ? await import(/* webpackIgnore: true */'node:"
 
 internal const val LOAD_MODULE_POSTFIX = "') : null)"
+
+internal const val RunSingleWithOutputSplitter = "runSingleWithOutputSplitter"

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/Utils.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/Utils.kt
@@ -29,5 +29,3 @@ internal const val LOAD_MODULE_PREFIX =
     "((module) => () => module)(((typeof process !== 'undefined') && (process.release.name === 'node')) ? await import(/* webpackIgnore: true */'node:"
 
 internal const val LOAD_MODULE_POSTFIX = "') : null)"
-
-internal const val RunSingleWithOutputSplitter = "runSingleWithOutputSplitter"

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/fs.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/fs.kt
@@ -20,6 +20,11 @@ internal external interface Fs {
      * See https://nodejs.org/api/fs.html#fsappendfilesyncpath-data-options
      */
     fun appendFileSync(file: String, text: String, options: String?)
+
+    /**
+     * See https://nodejs.org/api/fs.html#fswritesyncfd-buffer-options
+     */
+    fun writeSync(fd: Int, data: String)
 }
 
 internal val fs: Fs by lazy {

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmJsExecutorFactory.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmJsExecutorFactory.kt
@@ -5,9 +5,7 @@ import kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi
 
 @KotlinxBenchmarkRuntimeInternalApi
 fun runBenchmarks(name: String, args: Array<out String>, declareAndExecuteSuites: (SuiteExecutorBase) -> Unit) {
-    jsPromiseIntegration {
-        runBenchmarksImpl(name, args, declareAndExecuteSuites)
-    }
+    runBenchmarksImpl(name, args, declareAndExecuteSuites)
 }
 
 /**
@@ -47,25 +45,43 @@ internal fun runBenchmarksImpl(name: String, @Suppress("unused") args: Array<out
     }
 
     val executor = when {
-        arguments.size == 2 -> {
-            check (arguments[1] == "startAll")
+        arguments.any { it == "startAll" } -> {
             WasmBuiltInExecutor(name, configPath)
         }
 
-        arguments.size == 3 -> {
+        arguments.any { it == "runSingle" } -> {
+            val newArguments = arguments.filterNot { it == "runSingle" }.toTypedArray()
             SingleBenchmarkExecutor(
                 executionName = name,
                 runnerConfiguration = config,
-                suiteId = arguments[1],
-                benchmarkId = arguments[2],
+                suiteId = newArguments[1],
+                benchmarkId = newArguments[2],
             )
         }
 
-        arguments.size > 3 -> {
-            error("Unexpected ${arguments.size} argument(s)")
+        arguments.any { it == RunSingleWithOutputSplitter } -> {
+            val modulePath = nodeJsEngineModulePath()
+            val engineBinaryPath = engineBinaryPath ?: nodeJsEngineBinaryPath()
+            val engineWorkingPath = engineWorkingPath ?: nodeJsGetDirName(modulePath)
+
+            val runSingleArguments = arguments.filterNot { it == RunSingleWithOutputSplitter } + "runSingle"
+            val jsArguments = getJsParameters(engineArguments, modulePath, runSingleArguments)
+
+            println("Spawning $engineName...")
+            spawnProcessAsyncAndProcessTags(
+                binaryPath = engineBinaryPath,
+                workingDir = engineWorkingPath,
+                engineArguments = jsArguments,
+                processResultTags = true
+            )
+            return
         }
 
-        config.advanced["wasmFork"] != "perBenchmark" -> {
+        config.advanced["wasmFork"] == "perBenchmark" -> {
+            SpawnBenchmarkExecutor(name = name, configPath = configPath)
+        }
+
+        else -> {
             if (engineBinaryPath == null && engineArguments == null) {
                 WasmBuiltInExecutor(name, configPath)
             } else {
@@ -73,24 +89,14 @@ internal fun runBenchmarksImpl(name: String, @Suppress("unused") args: Array<out
                 val scriptDirectory = engineWorkingPath ?: nodeJsGetDirName(modulePath)
                 val jsParameters = getJsParameters(engineArguments, modulePath, listOf(configPath, "startAll"))
                 println("Spawning $engineName...")
-                spawnProcess(
+                spawnProcessAsyncAndProcessTags(
                     binaryPath = engineBinaryPath ?: nodeJsEngineBinaryPath(),
                     workingDir = scriptDirectory,
                     engineArguments = jsParameters,
+                    processResultTags = false,
                 )
                 return
             }
-        }
-
-        else -> {
-            SpawnBenchmarkExecutor(
-                name = name,
-                configPath = configPath,
-                engineName = engineName,
-                engineBinaryPath = engineBinaryPath ?: nodeJsEngineBinaryPath(),
-                engineWorkingDir = engineWorkingPath,
-                engineArguments = engineArguments,
-            )
         }
     }
 

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmJsExecutorFactory.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmJsExecutorFactory.kt
@@ -27,9 +27,8 @@ fun runBenchmarks(name: String, args: Array<out String>, declareAndExecuteSuites
  * @param declareAndExecuteSuites callback that declares benchmark suites and executes them with the selected executor
  */
 internal fun runBenchmarksImpl(name: String, @Suppress("unused") args: Array<out String>, declareAndExecuteSuites: (SuiteExecutorBase) -> Unit) {
-    val arguments = engineSupport.arguments()
-    val configPath = arguments[0]
-    val config = RunnerConfiguration(configPath.readFile())
+    val arguments = StartArguments.parse(engineSupport.arguments())
+    val config = RunnerConfiguration(arguments.config.readFile())
 
     val engineName= config.advanced["customEngineName"] ?: "Custom Engine"
     val engineBinaryPath = config.advanced["customEngineBinaryPath"]
@@ -44,28 +43,25 @@ internal fun runBenchmarksImpl(name: String, @Suppress("unused") args: Array<out
         engineArgumentIndex++
     }
 
-    val executor = when {
-        arguments.any { it == "startAll" } -> {
-            WasmBuiltInExecutor(name, configPath)
+    val executor = when (arguments.mode) {
+        StartMode.StartAll -> {
+            WasmBuiltInExecutor(name, arguments.config)
         }
 
-        arguments.any { it == "runSingle" } -> {
-            val newArguments = arguments.filterNot { it == "runSingle" }.toTypedArray()
+        StartMode.RunSingle -> {
             SingleBenchmarkExecutor(
                 executionName = name,
                 runnerConfiguration = config,
-                suiteId = newArguments[1],
-                benchmarkId = newArguments[2],
+                suiteId = arguments.suiteId ?: error("suiteId must be specified"),
+                benchmarkId = arguments.benchmarkId ?: error("benchmarkId must be specified"),
             )
         }
 
-        arguments.any { it == RunSingleWithOutputSplitter } -> {
+        StartMode.RunSingleWithOutputSplitter -> {
             val modulePath = nodeJsEngineModulePath()
             val engineBinaryPath = engineBinaryPath ?: nodeJsEngineBinaryPath()
             val engineWorkingPath = engineWorkingPath ?: nodeJsGetDirName(modulePath)
-
-            val runSingleArguments = arguments.filterNot { it == RunSingleWithOutputSplitter } + "runSingle"
-            val jsArguments = getJsParameters(engineArguments, modulePath, runSingleArguments)
+            val jsArguments = getJsParameters(engineArguments, modulePath, arguments.copy(mode = StartMode.RunSingle))
 
             println("Spawning $engineName...")
             spawnProcessAsyncAndProcessTags(
@@ -77,25 +73,33 @@ internal fun runBenchmarksImpl(name: String, @Suppress("unused") args: Array<out
             return
         }
 
-        config.advanced["wasmFork"] == "perBenchmark" -> {
-            SpawnBenchmarkExecutor(name = name, configPath = configPath)
-        }
+        StartMode.Default -> {
+            when {
+                config.advanced["wasmFork"] == "perBenchmark" -> {
+                    SpawnBenchmarkExecutor(name = name, configPath = arguments.config)
+                }
 
-        else -> {
-            if (engineBinaryPath == null && engineArguments == null) {
-                WasmBuiltInExecutor(name, configPath)
-            } else {
-                val modulePath = nodeJsEngineModulePath()
-                val scriptDirectory = engineWorkingPath ?: nodeJsGetDirName(modulePath)
-                val jsParameters = getJsParameters(engineArguments, modulePath, listOf(configPath, "startAll"))
-                println("Spawning $engineName...")
-                spawnProcessAsyncAndProcessTags(
-                    binaryPath = engineBinaryPath ?: nodeJsEngineBinaryPath(),
-                    workingDir = scriptDirectory,
-                    engineArguments = jsParameters,
-                    processResultTags = false,
-                )
-                return
+                engineBinaryPath == null && engineArguments == null -> {
+                    WasmBuiltInExecutor(name, arguments.config)
+                }
+
+                else  -> {
+                    val modulePath = nodeJsEngineModulePath()
+                    val scriptDirectory = engineWorkingPath ?: nodeJsGetDirName(modulePath)
+                    val jsParameters = getJsParameters(
+                        engineArguments,
+                        modulePath,
+                        StartArguments(arguments.config, StartMode.StartAll)
+                    )
+                    println("Spawning $engineName...")
+                    spawnProcessAsyncAndProcessTags(
+                        binaryPath = engineBinaryPath ?: nodeJsEngineBinaryPath(),
+                        workingDir = scriptDirectory,
+                        engineArguments = jsParameters,
+                        processResultTags = false,
+                    )
+                    return
+                }
             }
         }
     }

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmPerProcessExecutors.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmPerProcessExecutors.kt
@@ -24,10 +24,11 @@ internal class SpawnBenchmarkExecutor(
         val modulePath = nodeJsEngineModulePath()
         val workingDir = nodeJsGetDirName(modulePath)
 
+        val arguments = StartArguments(configPath, StartMode.RunSingleWithOutputSplitter, suiteId, benchmarkId)
         val jsParameters = getJsParameters(
             engineArguments = null,
             modulePath = modulePath,
-            arguments = listOf(configPath, suiteId, benchmarkId, RunSingleWithOutputSplitter)
+            startArguments = arguments
         )
 
         val result = jsSpawnProcessWithExtraPipeSyncAndGetResult(

--- a/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmPerProcessExecutors.kt
+++ b/runtime/wasmJsMain/src/kotlinx/benchmark/wasm/WasmPerProcessExecutors.kt
@@ -8,10 +8,6 @@ import kotlinx.benchmark.*
 internal class SpawnBenchmarkExecutor(
     name: String,
     private val configPath: String,
-    private val engineName: String,
-    private val engineBinaryPath: String,
-    private val engineWorkingDir: String?,
-    private val engineArguments: List<String>?,
     xmlReporter: (() -> BenchmarkProgress)? = null,
 ) : RunAllBenchmarksExtension, SuiteExecutor(name, configPath, xmlReporter) {
     override fun runBenchmark(
@@ -23,26 +19,36 @@ internal class SpawnBenchmarkExecutor(
     ): DoubleArray? {
         val benchmarkId = id.replaceSpaceWithPercent()
         val suiteId = benchmark.suite.name.replaceSpaceWithPercent()
+
+        val nodeJsPath = nodeJsEngineBinaryPath()
         val modulePath = nodeJsEngineModulePath()
-        val scriptDirectory = engineWorkingDir ?: nodeJsGetDirName(modulePath)
+        val workingDir = nodeJsGetDirName(modulePath)
 
-        val jsParameters =
-            getJsParameters(engineArguments, modulePath, listOf(configPath, suiteId, benchmarkId))
+        val jsParameters = getJsParameters(
+            engineArguments = null,
+            modulePath = modulePath,
+            arguments = listOf(configPath, suiteId, benchmarkId, RunSingleWithOutputSplitter)
+        )
 
-        val result = spawnProcessAndGetResult(engineBinaryPath, scriptDirectory, jsParameters)
+        val result = jsSpawnProcessWithExtraPipeSyncAndGetResult(
+            childProcess = childProcess,
+            binaryPath = nodeJsPath,
+            workingDir = workingDir,
+            engineArguments = jsParameters,
+        )
+
+        if (result.isNullOrBlank()) return null
 
         return result
-            ?.split(',')
-            ?.map { Double.fromBits(it.toLong()) }
-            ?.toDoubleArray()
+            .split(',')
+            .map { Double.fromBits(it.toLong()) }
+            .toDoubleArray()
     }
 
     override fun run(
         runnerConfiguration: RunnerConfiguration,
         benchmarks: List<BenchmarkDescriptor<Any?>>,
         start: () -> Unit,
-        complete: () -> Unit) {
-            println("Spawning $engineName...")
-            super<RunAllBenchmarksExtension>.run(runnerConfiguration, benchmarks, start, complete)
-        }
+        complete: () -> Unit
+    ) = super<RunAllBenchmarksExtension>.run(runnerConfiguration, benchmarks, start, complete)
 }

--- a/runtime/wasmWasiMain/src/kotlinx/benchmark/WasiEngineSupport.kt
+++ b/runtime/wasmWasiMain/src/kotlinx/benchmark/WasiEngineSupport.kt
@@ -79,7 +79,7 @@ private object WasiEngineSupport : BenchmarkEngineSupport() {
     }
 
     override fun arguments(): Array<out String> =
-        wasiGetArguments().toTypedArray()
+        wasiGetArguments().let { it.slice(2 .. it.lastIndex) }.toTypedArray()
 
     override fun getMeasurer(): Measurer = WasiMeasurer()
 

--- a/runtime/wasmWasiMain/src/kotlinx/benchmark/wasm/WasmWasiExecutorFactory.kt
+++ b/runtime/wasmWasiMain/src/kotlinx/benchmark/wasm/WasmWasiExecutorFactory.kt
@@ -2,32 +2,25 @@ package kotlinx.benchmark.wasm
 
 import kotlinx.benchmark.*
 import kotlinx.benchmark.internal.KotlinxBenchmarkRuntimeInternalApi
-import kotlinx.benchmark.wasm.wasi.wasiGetArguments
 
 @KotlinxBenchmarkRuntimeInternalApi
 fun runBenchmarks(name: String, @Suppress("unused") args: Array<out String>, declareAndExecuteSuites: (SuiteExecutorBase) -> Unit) {
-    val arguments = wasiGetArguments()
+    val arguments = StartArguments.parse(engineSupport.arguments())
 
-    val executor = when {
-        arguments.any { it == "startAll" } -> {
-            val newArguments = arguments.filterNot { it == "startAll" }.toTypedArray()
-            val configPath = newArguments[2]
-            WasmWasiBuiltInExecutor(name, configPath)
+    val executor = when(arguments.mode) {
+        StartMode.Default, StartMode.StartAll -> {
+            WasmWasiBuiltInExecutor(name, arguments.config)
         }
-        arguments.any { it == "runSingle" } -> {
-            val newArguments = arguments.filterNot { it == "runSingle" }.toTypedArray()
-            val configPath = newArguments[2]
-            val config = RunnerConfiguration(configPath.readFile())
+        StartMode.RunSingle -> {
             SingleBenchmarkExecutor(
                 executionName = name,
-                runnerConfiguration = config,
-                suiteId = arguments[3],
-                benchmarkId = arguments[4],
+                runnerConfiguration = RunnerConfiguration(arguments.config.readFile()),
+                suiteId = arguments.suiteId ?: error("suiteId must be specified"),
+                benchmarkId = arguments.benchmarkId ?: error("benchmarkId must be specified"),
             )
         }
         else -> {
-            val configPath = arguments[2]
-            WasmWasiBuiltInExecutor(name, configPath)
+            error("Unexpected arguments ${arguments.toArray().joinToString(" ")}")
         }
     }
 

--- a/runtime/wasmWasiMain/src/kotlinx/benchmark/wasm/WasmWasiExecutorFactory.kt
+++ b/runtime/wasmWasiMain/src/kotlinx/benchmark/wasm/WasmWasiExecutorFactory.kt
@@ -7,18 +7,16 @@ import kotlinx.benchmark.wasm.wasi.wasiGetArguments
 @KotlinxBenchmarkRuntimeInternalApi
 fun runBenchmarks(name: String, @Suppress("unused") args: Array<out String>, declareAndExecuteSuites: (SuiteExecutorBase) -> Unit) {
     val arguments = wasiGetArguments()
-    check (arguments.size >= 3) { "Unexpected number of arguments: ${arguments.size}"}
-    val configPath = arguments[2]
 
-    val executor = when (arguments.size) {
-        3 -> {
+    val executor = when {
+        arguments.any { it == "startAll" } -> {
+            val newArguments = arguments.filterNot { it == "startAll" }.toTypedArray()
+            val configPath = newArguments[2]
             WasmWasiBuiltInExecutor(name, configPath)
         }
-        4 -> {
-            check (arguments[3] == "startAll")
-            WasmWasiBuiltInExecutor(name, configPath)
-        }
-        5 -> {
+        arguments.any { it == "runSingle" } -> {
+            val newArguments = arguments.filterNot { it == "runSingle" }.toTypedArray()
+            val configPath = newArguments[2]
             val config = RunnerConfiguration(configPath.readFile())
             SingleBenchmarkExecutor(
                 executionName = name,
@@ -27,7 +25,10 @@ fun runBenchmarks(name: String, @Suppress("unused") args: Array<out String>, dec
                 benchmarkId = arguments[4],
             )
         }
-        else -> error("Unexpected number of arguments: ${arguments.size}")
+        else -> {
+            val configPath = arguments[2]
+            WasmWasiBuiltInExecutor(name, configPath)
+        }
     }
 
     declareAndExecuteSuites(executor)


### PR DESCRIPTION
In kotlin.wasm we are going to redesign js part of wasm app. So wasmExports will not be available to use from kotlin. That means that JSPI not cannot be configured from Kotlin.

Here, I remake the way how we wait for a process in a wasm perBenchmark mode to avoid JSPI.
I made a special nodejs process which is intermediate between benchmark engine and benchmark runner, which waits for other process and splits the result from console output into a special output pipe.