### PR TITLE
Update nodejs version used in test

### DIFF
--- a/integration/src/test/resources/templates/wasm-custom-engine/build.gradle
+++ b/integration/src/test/resources/templates/wasm-custom-engine/build.gradle
@@ -6,7 +6,7 @@ kotlin {
 }
 
 def nodeJsSpec = extensions.getByName('kotlinWasmNodeJsSpec') as WasmNodeJsEnvSpec
-nodeJsSpec.version.set('25.0.0') //Needed to support V8 JSPI
+nodeJsSpec.version.set('26.5.0') // Needed to support V8 JSPI
 
 def nodeJsEngine = new CustomEngine(
     'CustomNodeJs',


### PR DESCRIPTION
When project is built with the latest Kotlin version, CustomEngineTest fails due to incompatible NodeJs verison. The compatibility requirement is set by one of the dependencies, and it demands NodeJs either < 25 or > 25.