### PR TITLE
Implement custom engine execution for K/N performance tasks

### DIFF
--- a/examples/kotlin-multiplatform/build.gradle.kts
+++ b/examples/kotlin-multiplatform/build.gradle.kts
@@ -90,6 +90,17 @@ benchmark {
             iterationTime = 300 // time in ms per iteration
             iterationTimeUnit = "ms" // time in ms per iteration
             advanced("nativeGCAfterIteration", true)
+
+            @OptIn(KotlinxBenchmarkPluginExperimentalApi::class)
+            customEngine = CustomEngine(
+                name = "bash",
+                enginePath = project.layout.file(
+                    project.provider { File("/bin/bash") }
+                ),
+                engineArguments = providers.provider {
+                    listOf("-c")
+                }
+            )
         }
 
         create("csv") {

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinNativeTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinNativeTest.kt
@@ -1,5 +1,6 @@
 package kotlinx.benchmark.integration
 
+import org.junit.Assume
 import org.junit.Test
 
 class KotlinNativeTest : GradleTest() {
@@ -17,6 +18,10 @@ class KotlinNativeTest : GradleTest() {
 
     @Test
     fun nativeCustomEngine() {
+        Assume.assumeFalse(
+            "Specific CustomEngine that uses bash",
+            System.getProperty("os.name").lowercase().contains("windows")
+        )
         project("kotlin-native", true).let { runner ->
             val target = "native"
             val capitalizedTarget = target.replaceFirstChar { it.uppercaseChar() }

--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinNativeTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/KotlinNativeTest.kt
@@ -14,4 +14,18 @@ class KotlinNativeTest : GradleTest() {
             runner.runAndSucceed(":${capitalizedTarget}Benchmark")
         }
     }
+
+    @Test
+    fun nativeCustomEngine() {
+        project("kotlin-native", true).let { runner ->
+            val target = "native"
+            val capitalizedTarget = target.replaceFirstChar { it.uppercaseChar() }
+            val config = "custom"
+            val capitalizedConfig = config.replaceFirstChar { it.uppercaseChar() }
+
+            runner.runAndSucceed(":${target}BenchmarkGenerate")
+            runner.runAndSucceed(":compile${capitalizedTarget}BenchmarkKotlin${capitalizedTarget}")
+            runner.runAndSucceed(":${capitalizedTarget}${capitalizedConfig}Benchmark")
+        }
+    }
 }

--- a/integration/src/test/resources/templates/kotlin-native/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-native/build.gradle
@@ -1,15 +1,25 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.jetbrains.kotlin.konan.target.HostManager
+import kotlinx.benchmark.gradle.CustomEngine
 
 kotlin {
     if (HostManager.hostIsLinux) linuxX64('native')
-    if (HostManager.hostIsMingw) mingwX64('native')
     if (HostManager.host == KonanTarget.MACOS_ARM64.INSTANCE) macosArm64('native')
-    if (HostManager.host == KonanTarget.MACOS_X64.INSTANCE) macosX64('native')
 }
 
 benchmark {
+    configurations {
+        create("custom") {
+            customEngine = new CustomEngine(
+                    "bash",
+                    layout.file(provider { new File("/bin/bash") }),
+                    null,
+                    provider { ["-c"] }
+            )
+        }
+    }
+
     targets {
         register("native") {
             buildType = NativeBuildType.DEBUG

--- a/integration/src/test/resources/templates/kotlin-native/build.gradle
+++ b/integration/src/test/resources/templates/kotlin-native/build.gradle
@@ -5,18 +5,22 @@ import kotlinx.benchmark.gradle.CustomEngine
 
 kotlin {
     if (HostManager.hostIsLinux) linuxX64('native')
+    if (HostManager.hostIsMingw) mingwX64('native')
     if (HostManager.host == KonanTarget.MACOS_ARM64.INSTANCE) macosArm64('native')
+    if (HostManager.host == KonanTarget.MACOS_X64.INSTANCE) macosX64('native')
 }
 
 benchmark {
     configurations {
-        create("custom") {
-            customEngine = new CustomEngine(
-                    "bash",
-                    layout.file(provider { new File("/bin/bash") }),
-                    null,
-                    provider { ["-c"] }
-            )
+        if (!HostManager.hostIsMingw) {
+            create("custom") {
+                customEngine = new CustomEngine(
+                        "bash",
+                        layout.file(provider { new File("/bin/bash") }),
+                        null,
+                        provider { ["-c"] }
+                )
+            }
         }
     }
 

--- a/plugin/api/kotlinx-benchmark-plugin.api
+++ b/plugin/api/kotlinx-benchmark-plugin.api
@@ -161,6 +161,7 @@ public abstract class kotlinx/benchmark/gradle/NativeBenchmarkExec : org/gradle/
 	public final fun getBenchProgressPath ()Ljava/lang/String;
 	public final fun getBenchsDescriptionDir ()Ljava/io/File;
 	public final fun getConfigFile ()Ljava/io/File;
+	public final fun getEngine ()Lkotlinx/benchmark/gradle/CustomEngine;
 	public final fun getExecutable ()Ljava/io/File;
 	public final fun getNativeFork ()Ljava/lang/String;
 	public final fun getReportFile ()Ljava/io/File;
@@ -169,6 +170,7 @@ public abstract class kotlinx/benchmark/gradle/NativeBenchmarkExec : org/gradle/
 	public final fun setBenchProgressPath (Ljava/lang/String;)V
 	public final fun setBenchsDescriptionDir (Ljava/io/File;)V
 	public final fun setConfigFile (Ljava/io/File;)V
+	public final fun setEngine (Lkotlinx/benchmark/gradle/CustomEngine;)V
 	public final fun setExecutable (Ljava/io/File;)V
 	public final fun setNativeFork (Ljava/lang/String;)V
 	public final fun setReportFile (Ljava/io/File;)V

--- a/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/BenchmarkConfiguration.kt
@@ -15,9 +15,20 @@ import kotlin.text.replaceFirstChar
 
 @KotlinxBenchmarkPluginExperimentalApi
 class CustomEngine(
+    @get:Input
     val name: String,
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     val enginePath: Provider<RegularFile>,
+
+    @get:Optional
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     val workingDir: Provider<Directory>? = null,
+
+    @get:Optional
+    @get:Input
     val engineArguments: Provider<List<String>>? = null,
 )
 

--- a/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/NativeMultiplatformTasks.kt
@@ -133,6 +133,9 @@ fun Project.createNativeBenchmarkExecTask(
         this.workingDir = target.workingDir
         this.benchProgressPath = createTempFile("bench", ".txt").absolutePath
 
+        @OptIn(KotlinxBenchmarkPluginExperimentalApi::class)
+        this.engine = config.customEngine
+
         benchsDescriptionDir = project.layout.buildDirectory
             .dir("${target.extension.benchsDescriptionDir}/${config.name}")
             .get().asFile
@@ -183,19 +186,51 @@ constructor(
     @Internal
     lateinit var benchProgressPath: String
 
+    /**
+     * The [CustomEngine] used to run the benchmark [executable], if any.
+     */
+    @get:Nested
+    @get:Optional
+    @KotlinxBenchmarkPluginExperimentalApi
+    var engine: CustomEngine? = null
+
+    @OptIn(KotlinxBenchmarkPluginExperimentalApi::class)
+    private fun resolveEngineArguments(): List<String> =
+        engine?.engineArguments?.orNull?.takeIf { it.isNotEmpty() } ?: emptyList()
+
+    @OptIn(KotlinxBenchmarkPluginExperimentalApi::class)
     private fun execute(args: Collection<String>) {
+        val engineExecutable = engine?.enginePath?.orNull?.asFile
         execOperations.exec {
-            it.executable = executable.absolutePath
-            it.args(args)
-            workingDir?.let { dir ->
-                it.workingDir = File(dir)
+            if (engineExecutable != null) {
+                it.executable = engineExecutable.absolutePath
+                val engineArgs = resolveEngineArguments()
+                // Should be passed to the engine executable as an argument
+                val executableArgs = (listOf(executable.absolutePath) + args).joinToString(" ")
+                it.args(engineArgs + executableArgs)
+                val workDir = engine?.workingDir?.orNull?.asFile
+                    ?: workingDir?.let(::File)
+                if (workDir != null) {
+                    it.workingDir = workDir
+                }
+            } else {
+                it.executable = executable.absolutePath
+                it.args(args)
+                workingDir?.let { dir ->
+                    it.workingDir = File(dir)
+                }
             }
         }
     }
 
-    @OptIn(ExperimentalPathApi::class)
+    @OptIn(ExperimentalPathApi::class, KotlinxBenchmarkPluginExperimentalApi::class)
     @TaskAction
     fun run() {
+        engine?.let { engine ->
+            logger.lifecycle("Running benchmarks with '${engine.name}': " +
+                    "${engine.enginePath.orNull?.asFile?.absolutePath}")
+        }
+
         // Get full list of running benchmarks
         execute(listOf(configFile.absolutePath, "--list", benchProgressPath, benchsDescriptionDir.absolutePath))
         val detailedConfigFiles = objectFactory.fileTree().from(benchsDescriptionDir).files.sortedBy { it.absolutePath }
@@ -212,7 +247,15 @@ constructor(
             // Execute benchmark
             if (forkPerBenchmark) {
                 val suiteResultsFile = createTempFile("bench", ".txt")
-                execute(listOf(configFile.absolutePath, "--benchmark", benchProgressPath, runConfigPath, suiteResultsFile.absolutePath))
+                execute(
+                    listOf(
+                        configFile.absolutePath,
+                        "--benchmark",
+                        benchProgressPath,
+                        runConfigPath,
+                        suiteResultsFile.absolutePath
+                    )
+                )
                 val suiteResults = suiteResultsFile.readText()
                 if (suiteResults.isNotEmpty())
                     runResults[runConfigPath] = suiteResults
@@ -226,7 +269,16 @@ constructor(
                 var textResult: Path? = null
                 for (i in 0 until warmups) {
                     textResult = createTempFile("bench", ".txt")
-                    execute(listOf(configFile.absolutePath, "--warmup", benchProgressPath, runConfigPath, i.toString(), textResult.absolutePath))
+                    execute(
+                        listOf(
+                            configFile.absolutePath,
+                            "--warmup",
+                            benchProgressPath,
+                            runConfigPath,
+                            i.toString(),
+                            textResult.absolutePath
+                        )
+                    )
                     val result = textResult.readLines().getOrNull(0)
                     if (result == "null") {
                         exceptionDuringExecution = true
@@ -241,8 +293,15 @@ constructor(
                 while (!exceptionDuringExecution && iteration in 0 until iterations) {
                     textResult = createTempFile("bench", ".txt")
                     execute(
-                        listOf(configFile.absolutePath, "--iteration", benchProgressPath, runConfigPath, iteration.toString(),
-                            cycles, textResult.absolutePath)
+                        listOf(
+                            configFile.absolutePath,
+                            "--iteration",
+                            benchProgressPath,
+                            runConfigPath,
+                            iteration.toString(),
+                            cycles,
+                            textResult.absolutePath
+                        )
                     )
                     val result = textResult.readLines()[0]
                     if (result == "null")
@@ -257,7 +316,13 @@ constructor(
                         out.write(iterationResults.joinToString { it.toString() })
                     }
                     execute(
-                        listOf(configFile.absolutePath, "--end-run", benchProgressPath, runConfigPath, iterationsResultsFile.absolutePath)
+                        listOf(
+                            configFile.absolutePath,
+                            "--end-run",
+                            benchProgressPath,
+                            runConfigPath,
+                            iterationsResultsFile.absolutePath
+                        )
                     )
                     runResults[runConfigPath] = iterationResults.joinToString()
                 }


### PR DESCRIPTION
Use CustomEngine as an executor of the tests to be able to run tests on Linux with various profiling and tuning tools like taskset or perf.