### PR TITLE
Fixed formatter issue caused by changed WASI Double.toString implementation

### DIFF
--- a/runtime/wasmWasiMain/src/kotlinx/benchmark/Utils.kt
+++ b/runtime/wasmWasiMain/src/kotlinx/benchmark/Utils.kt
@@ -36,10 +36,11 @@ private fun Double.toPlainString(): String {
     val mantissa = unsigned.substringBefore("e")
     val exponent = unsigned.substringAfter("e").toInt()
 
-    val integerPart = mantissa.substringBefore('.')
-    val fractionPart = mantissa.substringAfter('.', "")
+    val integerPart = mantissa.substringBefore('.').trimStart('0')
+    val fractionPart = mantissa.substringAfter('.', "").trimEnd('0')
 
     val digits = "$integerPart$fractionPart"
+    check(digits.isNotEmpty())
 
     val decimalPlaces = fractionPart.length
     val shift = exponent - decimalPlaces


### PR DESCRIPTION
Kotlin Wasm will change soon Double and Float stringifiers. This will trigger test TextBenchmarkReportFormatter failure. This is a fix to have tests passing.