### PR TITLE
Remove usage of `KlibMetadataFactories`

### DIFF
--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl.kt
@@ -2,20 +2,13 @@ package kotlinx.benchmark.gradle
 
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.library.KotlinLibrary
-import org.jetbrains.kotlin.library.metadata.BuiltInKlibMetadataDeserializedPackageFragment
-import org.jetbrains.kotlin.library.metadata.KlibDeserializedContainerSource
-import org.jetbrains.kotlin.library.metadata.KlibMetadataCachedPackageFragment
-import org.jetbrains.kotlin.library.metadata.KlibMetadataDeserializedPackageFragment
-import org.jetbrains.kotlin.library.metadata.KlibMetadataDeserializedPackageFragmentsFactory
-import org.jetbrains.kotlin.library.metadata.PackageAccessHandler
-import org.jetbrains.kotlin.library.metadata.SimplePackageAccessHandler
-import org.jetbrains.kotlin.library.metadata.getIncompatibility
+import org.jetbrains.kotlin.library.metadata.*
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.serialization.deserialization.DeserializationConfiguration
 import org.jetbrains.kotlin.storage.StorageManager
 
-internal class CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl : KlibMetadataDeserializedPackageFragmentsFactory {
-    override fun createDeserializedPackageFragments(
+internal class CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl {
+    fun createDeserializedPackageFragments(
         library: KotlinLibrary,
         packageFragmentNames: List<String>,
         moduleDescriptor: ModuleDescriptor,
@@ -57,7 +50,7 @@ internal class CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl : KlibMet
         }
     }
 
-    override fun createCachedPackageFragments(
+    fun createCachedPackageFragments(
         packageFragments: List<ByteArray>,
         moduleDescriptor: ModuleDescriptor,
         storageManager: StorageManager

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl.kt
@@ -1,0 +1,68 @@
+package kotlinx.benchmark.gradle
+
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.metadata.BuiltInKlibMetadataDeserializedPackageFragment
+import org.jetbrains.kotlin.library.metadata.KlibDeserializedContainerSource
+import org.jetbrains.kotlin.library.metadata.KlibMetadataCachedPackageFragment
+import org.jetbrains.kotlin.library.metadata.KlibMetadataDeserializedPackageFragment
+import org.jetbrains.kotlin.library.metadata.KlibMetadataDeserializedPackageFragmentsFactory
+import org.jetbrains.kotlin.library.metadata.PackageAccessHandler
+import org.jetbrains.kotlin.library.metadata.SimplePackageAccessHandler
+import org.jetbrains.kotlin.library.metadata.getIncompatibility
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.serialization.deserialization.DeserializationConfiguration
+import org.jetbrains.kotlin.storage.StorageManager
+
+internal class CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl : KlibMetadataDeserializedPackageFragmentsFactory {
+    override fun createDeserializedPackageFragments(
+        library: KotlinLibrary,
+        packageFragmentNames: List<String>,
+        moduleDescriptor: ModuleDescriptor,
+        packageAccessedHandler: PackageAccessHandler?,
+        storageManager: StorageManager,
+        configuration: DeserializationConfiguration
+    ): List<KlibMetadataDeserializedPackageFragment> {
+        val libraryHeader = (packageAccessedHandler ?: SimplePackageAccessHandler).loadModuleHeader(library)
+
+        return packageFragmentNames.flatMap {
+            val packageFqName = FqName(it)
+            val containerSource = KlibDeserializedContainerSource(
+                library, libraryHeader, configuration, packageFqName, incompatibility = library.getIncompatibility(configuration.metadataVersion)
+            )
+            val parts = library.packageMetadataParts(packageFqName.asString())
+            val isBuiltInModule = moduleDescriptor.builtIns.builtInsModule === moduleDescriptor
+            parts.map { partName ->
+                if (isBuiltInModule)
+                    BuiltInKlibMetadataDeserializedPackageFragment(
+                        packageFqName,
+                        library,
+                        packageAccessedHandler,
+                        storageManager,
+                        moduleDescriptor,
+                        partName,
+                        containerSource
+                    )
+                else
+                    KlibMetadataDeserializedPackageFragment(
+                        packageFqName,
+                        library,
+                        packageAccessedHandler,
+                        storageManager,
+                        moduleDescriptor,
+                        partName,
+                        containerSource
+                    )
+            }
+        }
+    }
+
+    override fun createCachedPackageFragments(
+        packageFragments: List<ByteArray>,
+        moduleDescriptor: ModuleDescriptor,
+        storageManager: StorageManager
+    ) = packageFragments.map { byteArray ->
+        KlibMetadataCachedPackageFragment(byteArray, storageManager, moduleDescriptor)
+    }
+
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
@@ -5,6 +5,7 @@
 
 package kotlinx.benchmark.gradle
 
+import org.jetbrains.kotlin.builtins.DefaultBuiltIns
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.functions.functionInterfacePackageFragmentProvider
 import org.jetbrains.kotlin.config.LanguageVersionSettings
@@ -21,6 +22,8 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.parentOrNull
 import org.jetbrains.kotlin.platform.jvm.isJvm
+import org.jetbrains.kotlin.platform.konan.NativePlatforms
+import org.jetbrains.kotlin.resolve.ImplicitIntegerCoercion
 import org.jetbrains.kotlin.resolve.KlibCompilerDeserializationConfiguration
 import org.jetbrains.kotlin.resolve.sam.SamConversionResolverImpl
 import org.jetbrains.kotlin.serialization.deserialization.*
@@ -32,6 +35,12 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
     override val packageFragmentsFactory: KlibMetadataDeserializedPackageFragmentsFactory,
     override val flexibleTypeDeserializer: FlexibleTypeDeserializer
 ) : KlibMetadataModuleDescriptorFactory {
+    companion object {
+        internal fun KlibModuleOrigin.isCInteropLibrary(): Boolean = when (this) {
+            is DeserializedKlibModuleOrigin -> this.library.isCInteropLibrary()
+            CurrentKlibModuleOrigin, SyntheticModulesOrigin -> false
+        }
+    }
 
     override fun createDescriptorOptionalBuiltIns(
         library: KotlinLibrary,
@@ -47,10 +56,21 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         val moduleName = Name.special(libraryProto.moduleName)
         val moduleOrigin = DeserializedKlibModuleOrigin(library)
 
-        val moduleDescriptor = if (builtIns != null)
-            descriptorFactory.createDescriptor(moduleName, storageManager, builtIns, moduleOrigin)
-        else
-            descriptorFactory.createDescriptorAndNewBuiltIns(moduleName, storageManager, moduleOrigin)
+        val builtInsToUse = builtIns ?: DefaultBuiltIns.Instance
+        val moduleDescriptor = ModuleDescriptorImpl(
+            moduleName,
+            storageManager,
+            builtInsToUse,
+            capabilities = mapOf(
+                KlibModuleOrigin.CAPABILITY to moduleOrigin,
+                ImplicitIntegerCoercion.MODULE_CAPABILITY to moduleOrigin.isCInteropLibrary()
+            ),
+            platform = NativePlatforms.unspecifiedNativePlatform
+        )
+
+        if (builtIns == null) {
+            builtInsToUse.builtInsModule = moduleDescriptor
+        }
 
         val provider = createPackageFragmentProvider(
             library,

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.isAnyPlatformStdlib
 import org.jetbrains.kotlin.library.metadata.*
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.parentOrNull
 import org.jetbrains.kotlin.platform.jvm.isJvm
@@ -31,10 +30,9 @@ import org.jetbrains.kotlin.storage.StorageManager
 import org.jetbrains.kotlin.utils.addToStdlib.runIf
 
 internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
-    override val descriptorFactory: KlibModuleDescriptorFactory,
-    override val packageFragmentsFactory: KlibMetadataDeserializedPackageFragmentsFactory,
-    override val flexibleTypeDeserializer: FlexibleTypeDeserializer
-) : KlibMetadataModuleDescriptorFactory {
+    val packageFragmentsFactory: CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl,
+    val flexibleTypeDeserializer: FlexibleTypeDeserializer
+) {
     companion object {
         internal fun KlibModuleOrigin.isCInteropLibrary(): Boolean = when (this) {
             is DeserializedKlibModuleOrigin -> this.library.isCInteropLibrary()
@@ -42,7 +40,31 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         }
     }
 
-    override fun createDescriptorOptionalBuiltIns(
+    fun createDescriptor(
+        library: KotlinLibrary,
+        languageVersionSettings: LanguageVersionSettings,
+        storageManager: StorageManager,
+        builtIns: KotlinBuiltIns,
+        packageAccessHandler: PackageAccessHandler?
+    ) = createDescriptorOptionalBuiltIns(
+        library,
+        languageVersionSettings,
+        storageManager,
+        builtIns,
+        packageAccessHandler,
+        LookupTracker.DO_NOTHING
+    )
+
+    fun createDescriptorAndNewBuiltIns(
+        library: KotlinLibrary,
+        languageVersionSettings: LanguageVersionSettings,
+        storageManager: StorageManager,
+        packageAccessHandler: PackageAccessHandler?
+    ) = createDescriptorOptionalBuiltIns(
+        library, languageVersionSettings, storageManager, null, packageAccessHandler, LookupTracker.DO_NOTHING
+    )
+
+    fun createDescriptorOptionalBuiltIns(
         library: KotlinLibrary,
         languageVersionSettings: LanguageVersionSettings,
         storageManager: StorageManager,
@@ -90,23 +112,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         return moduleDescriptor
     }
 
-    override fun createCachedPackageFragmentProvider(
-        byteArrays: List<ByteArray>,
-        storageManager: StorageManager,
-        moduleDescriptor: ModuleDescriptor,
-        configuration: DeserializationConfiguration,
-        lookupTracker: LookupTracker
-    ): PackageFragmentProvider {
-        val deserializedPackageFragments = packageFragmentsFactory.createCachedPackageFragments(
-            byteArrays, moduleDescriptor, storageManager
-        )
-
-        val provider = PackageFragmentProviderImpl(deserializedPackageFragments)
-        return initializePackageFragmentProvider(provider, deserializedPackageFragments, storageManager,
-            moduleDescriptor, configuration, null, lookupTracker)
-    }
-
-    override fun createPackageFragmentProvider(
+    fun createPackageFragmentProvider(
         library: KotlinLibrary,
         packageAccessHandler: PackageAccessHandler?,
         packageFragmentNames: List<String>,

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
@@ -51,8 +51,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         languageVersionSettings,
         storageManager,
         builtIns,
-        packageAccessHandler,
-        LookupTracker.DO_NOTHING
+        packageAccessHandler
     )
 
     fun createDescriptorAndNewBuiltIns(
@@ -61,7 +60,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         storageManager: StorageManager,
         packageAccessHandler: PackageAccessHandler?
     ) = createDescriptorOptionalBuiltIns(
-        library, languageVersionSettings, storageManager, null, packageAccessHandler, LookupTracker.DO_NOTHING
+        library, languageVersionSettings, storageManager, null, packageAccessHandler
     )
 
     fun createDescriptorOptionalBuiltIns(
@@ -69,8 +68,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         languageVersionSettings: LanguageVersionSettings,
         storageManager: StorageManager,
         builtIns: KotlinBuiltIns?,
-        packageAccessHandler: PackageAccessHandler?,
-        lookupTracker: LookupTracker
+        packageAccessHandler: PackageAccessHandler?
     ): ModuleDescriptorImpl {
 
         val libraryProto = parseModuleHeader(library.moduleHeaderData)
@@ -103,8 +101,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
             configuration = KlibCompilerDeserializationConfiguration(languageVersionSettings),
             compositePackageFragmentAddend = runIf(library.isAnyPlatformStdlib) {
                 functionInterfacePackageFragmentProvider(storageManager, moduleDescriptor)
-            },
-            lookupTracker = lookupTracker
+            }
         )
 
         moduleDescriptor.initialize(provider)
@@ -119,8 +116,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         storageManager: StorageManager,
         moduleDescriptor: ModuleDescriptor,
         configuration: DeserializationConfiguration,
-        compositePackageFragmentAddend: PackageFragmentProvider?,
-        lookupTracker: LookupTracker
+        compositePackageFragmentAddend: PackageFragmentProvider?
     ): PackageFragmentProvider {
 
         val deserializedPackageFragments = packageFragmentsFactory.createDeserializedPackageFragments(
@@ -144,7 +140,8 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
 
         val provider = PackageFragmentProviderImpl(deserializedPackageFragments + emptyPackageFragments)
         return initializePackageFragmentProvider(provider, deserializedPackageFragments, storageManager,
-            moduleDescriptor, configuration, compositePackageFragmentAddend, lookupTracker)
+            moduleDescriptor, configuration, compositePackageFragmentAddend
+        )
     }
 
     fun initializePackageFragmentProvider(
@@ -153,8 +150,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
         storageManager: StorageManager,
         moduleDescriptor: ModuleDescriptor,
         configuration: DeserializationConfiguration,
-        compositePackageFragmentAddend: PackageFragmentProvider?,
-        lookupTracker: LookupTracker
+        compositePackageFragmentAddend: PackageFragmentProvider?
     ): PackageFragmentProvider {
 
         val notFoundClasses = NotFoundClasses(storageManager, moduleDescriptor)
@@ -178,7 +174,7 @@ internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
             provider,
             LocalClassifierTypeSettings.Default,
             ErrorReporter.DO_NOTHING,
-            lookupTracker,
+            LookupTracker.DO_NOTHING,
             flexibleTypeDeserializer,
             emptyList(),
             notFoundClasses,

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibMetadataModuleDescriptorFactoryImpl.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlinx.benchmark.gradle
+
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.builtins.functions.functionInterfacePackageFragmentProvider
+import org.jetbrains.kotlin.config.LanguageVersionSettings
+import org.jetbrains.kotlin.contracts.ContractDeserializerImpl
+import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.descriptors.impl.CompositePackageFragmentProvider
+import org.jetbrains.kotlin.descriptors.impl.EmptyPackageFragmentDescriptor
+import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.incremental.components.LookupTracker
+import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.isAnyPlatformStdlib
+import org.jetbrains.kotlin.library.metadata.*
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.parentOrNull
+import org.jetbrains.kotlin.platform.jvm.isJvm
+import org.jetbrains.kotlin.resolve.KlibCompilerDeserializationConfiguration
+import org.jetbrains.kotlin.resolve.sam.SamConversionResolverImpl
+import org.jetbrains.kotlin.serialization.deserialization.*
+import org.jetbrains.kotlin.storage.StorageManager
+import org.jetbrains.kotlin.utils.addToStdlib.runIf
+
+internal class CopyKlibMetadataModuleDescriptorFactoryImpl(
+    override val descriptorFactory: KlibModuleDescriptorFactory,
+    override val packageFragmentsFactory: KlibMetadataDeserializedPackageFragmentsFactory,
+    override val flexibleTypeDeserializer: FlexibleTypeDeserializer
+) : KlibMetadataModuleDescriptorFactory {
+
+    override fun createDescriptorOptionalBuiltIns(
+        library: KotlinLibrary,
+        languageVersionSettings: LanguageVersionSettings,
+        storageManager: StorageManager,
+        builtIns: KotlinBuiltIns?,
+        packageAccessHandler: PackageAccessHandler?,
+        lookupTracker: LookupTracker
+    ): ModuleDescriptorImpl {
+
+        val libraryProto = parseModuleHeader(library.moduleHeaderData)
+
+        val moduleName = Name.special(libraryProto.moduleName)
+        val moduleOrigin = DeserializedKlibModuleOrigin(library)
+
+        val moduleDescriptor = if (builtIns != null)
+            descriptorFactory.createDescriptor(moduleName, storageManager, builtIns, moduleOrigin)
+        else
+            descriptorFactory.createDescriptorAndNewBuiltIns(moduleName, storageManager, moduleOrigin)
+
+        val provider = createPackageFragmentProvider(
+            library,
+            packageAccessHandler,
+            packageFragmentNames = libraryProto.packageFragmentNameList,
+            storageManager,
+            moduleDescriptor,
+            configuration = KlibCompilerDeserializationConfiguration(languageVersionSettings),
+            compositePackageFragmentAddend = runIf(library.isAnyPlatformStdlib) {
+                functionInterfacePackageFragmentProvider(storageManager, moduleDescriptor)
+            },
+            lookupTracker = lookupTracker
+        )
+
+        moduleDescriptor.initialize(provider)
+
+        return moduleDescriptor
+    }
+
+    override fun createCachedPackageFragmentProvider(
+        byteArrays: List<ByteArray>,
+        storageManager: StorageManager,
+        moduleDescriptor: ModuleDescriptor,
+        configuration: DeserializationConfiguration,
+        lookupTracker: LookupTracker
+    ): PackageFragmentProvider {
+        val deserializedPackageFragments = packageFragmentsFactory.createCachedPackageFragments(
+            byteArrays, moduleDescriptor, storageManager
+        )
+
+        val provider = PackageFragmentProviderImpl(deserializedPackageFragments)
+        return initializePackageFragmentProvider(provider, deserializedPackageFragments, storageManager,
+            moduleDescriptor, configuration, null, lookupTracker)
+    }
+
+    override fun createPackageFragmentProvider(
+        library: KotlinLibrary,
+        packageAccessHandler: PackageAccessHandler?,
+        packageFragmentNames: List<String>,
+        storageManager: StorageManager,
+        moduleDescriptor: ModuleDescriptor,
+        configuration: DeserializationConfiguration,
+        compositePackageFragmentAddend: PackageFragmentProvider?,
+        lookupTracker: LookupTracker
+    ): PackageFragmentProvider {
+
+        val deserializedPackageFragments = packageFragmentsFactory.createDeserializedPackageFragments(
+            library, packageFragmentNames, moduleDescriptor, packageAccessHandler, storageManager, configuration
+        )
+
+        // Generate empty PackageFragmentDescriptor instances for packages that aren't mentioned in compilation units directly.
+        // For example, if there's `package foo.bar` directive, we'll get only PackageFragmentDescriptor for `foo.bar`, but
+        // none for `foo`. Various descriptor/scope code relies on presence of such package fragments, and currently we
+        // don't know if it's possible to fix this.
+        // TODO: think about fixing issues in descriptors/scopes
+        val packageFqNames = deserializedPackageFragments.mapTo(mutableSetOf()) { it.fqName }
+        val emptyPackageFragments = mutableListOf<PackageFragmentDescriptor>()
+        for (packageFqName in packageFqNames.mapNotNull { it.parentOrNull() }) {
+            var ancestorFqName = packageFqName
+            while (!ancestorFqName.isRoot && packageFqNames.add(ancestorFqName)) {
+                emptyPackageFragments += EmptyPackageFragmentDescriptor(moduleDescriptor, ancestorFqName)
+                ancestorFqName = ancestorFqName.parent()
+            }
+        }
+
+        val provider = PackageFragmentProviderImpl(deserializedPackageFragments + emptyPackageFragments)
+        return initializePackageFragmentProvider(provider, deserializedPackageFragments, storageManager,
+            moduleDescriptor, configuration, compositePackageFragmentAddend, lookupTracker)
+    }
+
+    fun initializePackageFragmentProvider(
+        provider: PackageFragmentProviderImpl,
+        fragmentsToInitialize: List<DeserializedPackageFragment>,
+        storageManager: StorageManager,
+        moduleDescriptor: ModuleDescriptor,
+        configuration: DeserializationConfiguration,
+        compositePackageFragmentAddend: PackageFragmentProvider?,
+        lookupTracker: LookupTracker
+    ): PackageFragmentProvider {
+
+        val notFoundClasses = NotFoundClasses(storageManager, moduleDescriptor)
+
+        val annotationAndConstantLoader = AnnotationAndConstantLoaderImpl(
+            moduleDescriptor,
+            notFoundClasses,
+            KlibMetadataSerializerProtocol
+        )
+
+        val enumEntriesDeserializationSupport = object : EnumEntriesDeserializationSupport {
+            override fun canSynthesizeEnumEntries(): Boolean = moduleDescriptor.platform.isJvm()
+        }
+
+        val components = DeserializationComponents(
+            storageManager,
+            moduleDescriptor,
+            configuration,
+            DeserializedClassDataFinder(provider),
+            annotationAndConstantLoader,
+            provider,
+            LocalClassifierTypeSettings.Default,
+            ErrorReporter.DO_NOTHING,
+            lookupTracker,
+            flexibleTypeDeserializer,
+            emptyList(),
+            notFoundClasses,
+            ContractDeserializerImpl(configuration, storageManager),
+            extensionRegistryLite = KlibMetadataSerializerProtocol.extensionRegistry,
+            samConversionResolver = SamConversionResolverImpl(storageManager, samWithReceiverResolvers = emptyList()),
+            enumEntriesDeserializationSupport = enumEntriesDeserializationSupport,
+        )
+
+        fragmentsToInitialize.forEach {
+            it.initialize(components)
+        }
+
+        return compositePackageFragmentAddend?.let {
+            CompositePackageFragmentProvider(
+                listOf(it, provider),
+                "CompositeProvider@KlibMetadataModuleDescriptorFactory for $moduleDescriptor"
+            )
+        } ?: provider
+    }
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibResolvedModuleDescriptorsFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibResolvedModuleDescriptorsFactoryImpl.kt
@@ -5,17 +5,13 @@
 
 package kotlinx.benchmark.gradle
 
+import kotlinx.benchmark.gradle.CopyKlibMetadataModuleDescriptorFactoryImpl.Companion.isCInteropLibrary
+import org.jetbrains.kotlin.builtins.DefaultBuiltIns
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.config.LanguageVersionSettings
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.ClassKind
-import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.descriptors.PackageFragmentProviderImpl
-import org.jetbrains.kotlin.descriptors.SourceElement
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptorImpl
 import org.jetbrains.kotlin.descriptors.annotations.Annotations
-import org.jetbrains.kotlin.descriptors.annotations.Annotations.Companion
 import org.jetbrains.kotlin.descriptors.impl.ClassDescriptorImpl
 import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.descriptors.impl.PackageFragmentDescriptorImpl
@@ -23,17 +19,14 @@ import org.jetbrains.kotlin.incremental.components.LookupLocation
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.library.KotlinLibrary
-import org.jetbrains.kotlin.library.metadata.KlibMetadataModuleDescriptorFactory
-import org.jetbrains.kotlin.library.metadata.KlibModuleOrigin
-import org.jetbrains.kotlin.library.metadata.KlibResolvedModuleDescriptorsFactory
-import org.jetbrains.kotlin.library.metadata.KotlinResolvedModuleDescriptors
-import org.jetbrains.kotlin.library.metadata.PackageAccessHandler
-import org.jetbrains.kotlin.library.metadata.SyntheticModulesOrigin
+import org.jetbrains.kotlin.library.metadata.*
 import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.NativeForwardDeclarationKind
 import org.jetbrains.kotlin.name.NativeStandardInteropNames
+import org.jetbrains.kotlin.platform.konan.NativePlatforms
+import org.jetbrains.kotlin.resolve.ImplicitIntegerCoercion
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
 import org.jetbrains.kotlin.resolve.scopes.MemberScopeImpl
@@ -164,10 +157,25 @@ internal class CopyKlibResolvedModuleDescriptorsFactoryImpl(
         storageManager: StorageManager,
         builtIns: KotlinBuiltIns?,
         moduleOrigin: KlibModuleOrigin
-    ) = if (builtIns != null)
-        moduleDescriptorFactory.descriptorFactory.createDescriptor(name, storageManager, builtIns, moduleOrigin)
-    else
-        moduleDescriptorFactory.descriptorFactory.createDescriptorAndNewBuiltIns(name, storageManager, moduleOrigin)
+    ): ModuleDescriptorImpl {
+        val builtInsToUse = builtIns ?: DefaultBuiltIns.Instance
+        val moduleDescriptor = ModuleDescriptorImpl(
+            name,
+            storageManager,
+            builtInsToUse,
+            capabilities = mapOf(
+                KlibModuleOrigin.CAPABILITY to moduleOrigin,
+                ImplicitIntegerCoercion.MODULE_CAPABILITY to moduleOrigin.isCInteropLibrary()
+            ),
+            platform = NativePlatforms.unspecifiedNativePlatform
+        )
+
+        if (builtIns == null) {
+            builtInsToUse.builtInsModule = moduleDescriptor
+        }
+
+        return moduleDescriptor
+    }
 
     private fun createDescriptorOptionalBuiltsIns(
         library: KotlinLibrary,

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibResolvedModuleDescriptorsFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibResolvedModuleDescriptorsFactoryImpl.kt
@@ -19,7 +19,10 @@ import org.jetbrains.kotlin.incremental.components.LookupLocation
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.konan.file.File
 import org.jetbrains.kotlin.library.KotlinLibrary
-import org.jetbrains.kotlin.library.metadata.*
+import org.jetbrains.kotlin.library.metadata.KlibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.KotlinResolvedModuleDescriptors
+import org.jetbrains.kotlin.library.metadata.PackageAccessHandler
+import org.jetbrains.kotlin.library.metadata.SyntheticModulesOrigin
 import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -37,10 +40,10 @@ import org.jetbrains.kotlin.util.profile
 import org.jetbrains.kotlin.utils.Printer
 
 internal class CopyKlibResolvedModuleDescriptorsFactoryImpl(
-    override val moduleDescriptorFactory: KlibMetadataModuleDescriptorFactory
-) : KlibResolvedModuleDescriptorsFactory {
+    val moduleDescriptorFactory: CopyKlibMetadataModuleDescriptorFactoryImpl
+) {
 
-    override fun createResolved(
+    fun createResolved(
         resolvedLibraries: KotlinLibraryResolveResult,
         storageManager: StorageManager,
         builtIns: KotlinBuiltIns?,

--- a/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibResolvedModuleDescriptorsFactoryImpl.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/CopyKlibResolvedModuleDescriptorsFactoryImpl.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package kotlinx.benchmark.gradle
+
+import org.jetbrains.kotlin.builtins.KotlinBuiltIns
+import org.jetbrains.kotlin.config.LanguageVersionSettings
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.PackageFragmentProviderImpl
+import org.jetbrains.kotlin.descriptors.SourceElement
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptorImpl
+import org.jetbrains.kotlin.descriptors.annotations.Annotations
+import org.jetbrains.kotlin.descriptors.annotations.Annotations.Companion
+import org.jetbrains.kotlin.descriptors.impl.ClassDescriptorImpl
+import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
+import org.jetbrains.kotlin.descriptors.impl.PackageFragmentDescriptorImpl
+import org.jetbrains.kotlin.incremental.components.LookupLocation
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation
+import org.jetbrains.kotlin.konan.file.File
+import org.jetbrains.kotlin.library.KotlinLibrary
+import org.jetbrains.kotlin.library.metadata.KlibMetadataModuleDescriptorFactory
+import org.jetbrains.kotlin.library.metadata.KlibModuleOrigin
+import org.jetbrains.kotlin.library.metadata.KlibResolvedModuleDescriptorsFactory
+import org.jetbrains.kotlin.library.metadata.KotlinResolvedModuleDescriptors
+import org.jetbrains.kotlin.library.metadata.PackageAccessHandler
+import org.jetbrains.kotlin.library.metadata.SyntheticModulesOrigin
+import org.jetbrains.kotlin.library.metadata.resolver.KotlinLibraryResolveResult
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.NativeForwardDeclarationKind
+import org.jetbrains.kotlin.name.NativeStandardInteropNames
+import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
+import org.jetbrains.kotlin.resolve.scopes.MemberScopeImpl
+import org.jetbrains.kotlin.storage.LockBasedStorageManager
+import org.jetbrains.kotlin.storage.StorageManager
+import org.jetbrains.kotlin.storage.getValue
+import org.jetbrains.kotlin.util.profile
+import org.jetbrains.kotlin.utils.Printer
+
+internal class CopyKlibResolvedModuleDescriptorsFactoryImpl(
+    override val moduleDescriptorFactory: KlibMetadataModuleDescriptorFactory
+) : KlibResolvedModuleDescriptorsFactory {
+
+    override fun createResolved(
+        resolvedLibraries: KotlinLibraryResolveResult,
+        storageManager: StorageManager,
+        builtIns: KotlinBuiltIns?,
+        languageVersionSettings: LanguageVersionSettings,
+        friendModuleFiles: Set<File>,
+        refinesModuleFiles: Set<File>,
+        includedLibraryFiles: Set<File>,
+        additionalDependencyModules: Iterable<ModuleDescriptorImpl>,
+        isForMetadataCompilation: Boolean,
+    ): KotlinResolvedModuleDescriptors {
+
+        val moduleDescriptors = mutableListOf<ModuleDescriptorImpl>()
+
+        @Suppress("NAME_SHADOWING")
+        var builtIns = builtIns
+
+        val friendModuleDescriptors = mutableSetOf<ModuleDescriptorImpl>()
+        val refinesModuleDescriptors = mutableSetOf<ModuleDescriptorImpl>()
+        val includedLibraryDescriptors = mutableSetOf<ModuleDescriptorImpl>()
+
+        // Build module descriptors.
+        resolvedLibraries.forEach { library, packageAccessHandler ->
+            profile("Loading ${library.libraryName}") {
+
+                // MutableModuleContext needs ModuleDescriptorImpl, rather than ModuleDescriptor.
+                val moduleDescriptor = createDescriptorOptionalBuiltsIns(
+                    library, languageVersionSettings, storageManager, builtIns, packageAccessHandler
+                )
+                builtIns = moduleDescriptor.builtIns
+                moduleDescriptors.add(moduleDescriptor)
+
+                if (refinesModuleFiles.contains(library.libraryFile))
+                    refinesModuleDescriptors.add(moduleDescriptor)
+                if (friendModuleFiles.contains(library.libraryFile))
+                    friendModuleDescriptors.add(moduleDescriptor)
+                if (includedLibraryFiles.contains(library.libraryFile))
+                    includedLibraryDescriptors.add(moduleDescriptor)
+            }
+        }
+
+        val forwardDeclarationsModule = createForwardDeclarationsModule(
+            builtIns,
+            storageManager,
+            // If we are compiling metadata, make synthetic forward declarations `expect`,
+            // because otherwise `getFirstClassifierDiscriminateHeaders` would prefer it over a
+            // "real" `expect` declaration from a commonized interop library, which would ruin
+            // the whole idea of using synthetic forward declarations only when no proper definitions
+            // are found.
+            //
+            // If we are compiling for the actual native platform, continue using non-expect
+            // forward declarations (to prevent getting non-actualized expects into the backend,
+            // and to prevent related klib signature changes).
+            isExpect = isForMetadataCompilation,
+        )
+
+        // Set inter-dependencies between module descriptors, add forwarding declarations module.
+        val additionalDependencyModulesCopy = additionalDependencyModules.toSet()
+        val friendsForNonIncludedModule = additionalDependencyModulesCopy
+        val friendsForIncludedModule = buildSet<ModuleDescriptorImpl> {
+            this += friendsForNonIncludedModule
+            this += friendModuleDescriptors
+            this += refinesModuleDescriptors
+        }
+        val allDependencies = moduleDescriptors + additionalDependencyModulesCopy + forwardDeclarationsModule
+        for (module in moduleDescriptors) {
+            val friends = if (module in includedLibraryDescriptors) {
+                friendsForIncludedModule
+            } else {
+                friendsForNonIncludedModule
+            }
+
+            // Yes, just to all of them.
+            module.setDependencies(allDependencies, friends)
+        }
+
+        return KotlinResolvedModuleDescriptors(
+            resolvedDescriptors = moduleDescriptors,
+            forwardDeclarationsModule = forwardDeclarationsModule,
+            friendModules = friendModuleDescriptors,
+            refinesModules = refinesModuleDescriptors
+        )
+    }
+
+    fun createForwardDeclarationsModule(
+        builtIns: KotlinBuiltIns?,
+        storageManager: StorageManager,
+        isExpect: Boolean
+    ): ModuleDescriptorImpl {
+
+        val module = createDescriptorOptionalBuiltsIns(FORWARD_DECLARATIONS_MODULE_NAME, storageManager, builtIns, SyntheticModulesOrigin)
+
+        fun createPackage(forwardDeclarationKind: NativeForwardDeclarationKind) =
+            ForwardDeclarationsPackageFragmentDescriptor(
+                storageManager,
+                module,
+                forwardDeclarationKind.packageFqName,
+                forwardDeclarationKind.superClassName,
+                forwardDeclarationKind.classKind,
+                isExpect
+            )
+
+        val packageFragmentProvider = PackageFragmentProviderImpl(
+            NativeForwardDeclarationKind.values().map { createPackage(it) }
+        )
+
+        module.initialize(packageFragmentProvider)
+        module.setDependencies(module)
+
+        return module
+    }
+
+    private fun createDescriptorOptionalBuiltsIns(
+        name: Name,
+        storageManager: StorageManager,
+        builtIns: KotlinBuiltIns?,
+        moduleOrigin: KlibModuleOrigin
+    ) = if (builtIns != null)
+        moduleDescriptorFactory.descriptorFactory.createDescriptor(name, storageManager, builtIns, moduleOrigin)
+    else
+        moduleDescriptorFactory.descriptorFactory.createDescriptorAndNewBuiltIns(name, storageManager, moduleOrigin)
+
+    private fun createDescriptorOptionalBuiltsIns(
+        library: KotlinLibrary,
+        languageVersionSettings: LanguageVersionSettings,
+        storageManager: StorageManager,
+        builtIns: KotlinBuiltIns?,
+        packageAccessHandler: PackageAccessHandler?
+    ) = if (builtIns != null)
+        moduleDescriptorFactory.createDescriptor(library, languageVersionSettings, storageManager, builtIns, packageAccessHandler)
+    else
+        moduleDescriptorFactory.createDescriptorAndNewBuiltIns(library, languageVersionSettings, storageManager, packageAccessHandler)
+
+    companion object {
+        val FORWARD_DECLARATIONS_MODULE_NAME = Name.special("<forward declarations>")
+    }
+}
+
+/**
+ * Package fragment which creates descriptors for forward declarations on demand.
+ */
+internal class ForwardDeclarationsPackageFragmentDescriptor(
+    storageManager: StorageManager,
+    module: ModuleDescriptor,
+    fqName: FqName,
+    supertypeName: Name,
+    classKind: ClassKind,
+    isExpect: Boolean
+) : PackageFragmentDescriptorImpl(module, fqName) {
+
+    private val memberScope = object : MemberScopeImpl() {
+
+        private val declarations = storageManager.createMemoizedFunction(this::createDeclaration)
+
+        private val supertype by storageManager.createLazyValue {
+            findCinteropClass(supertypeName).defaultType
+        }
+
+        /**
+         * Normally, this can't be null. But it's possible inside IDE, if one uses new IDE with
+         * old compiler in a project. In that case, IDE would try to generate synthetic declaration
+         * but would fail to find annotation class.
+         *
+         * A better way to do this would be introducing language feature, but unfortunately, we can't
+         * do it between 1.9.0 and 1.9.20.
+         */
+        private val experimentalAnnotationType by storageManager.createNullableLazyValue {
+            findCinteropClassOrNull(NativeStandardInteropNames.ExperimentalForeignApi)?.defaultType
+        }
+
+        private fun findCinteropClass(name: Name): ClassDescriptor = findCinteropClassOrNull(name) ?:
+          error("Class $name is not found")
+
+        private fun findCinteropClassOrNull(name: Name): ClassDescriptor? {
+            return builtIns.builtInsModule.getPackage(NativeStandardInteropNames.cInteropPackage)
+                .memberScope
+                .getContributedClassifier(name, NoLookupLocation.FROM_BACKEND) as ClassDescriptor?
+        }
+
+        private fun createDeclaration(name: Name): ClassDescriptor {
+            val experimentalAnnotation = experimentalAnnotationType?.let {
+                AnnotationDescriptorImpl(
+                    it,
+                    emptyMap(),
+                    SourceElement.NO_SOURCE
+                )
+            }
+
+            return object : ClassDescriptorImpl(
+                this@ForwardDeclarationsPackageFragmentDescriptor,
+                name,
+                Modality.FINAL,
+                classKind,
+                listOf(supertype),
+                SourceElement.NO_SOURCE,
+                false,
+                LockBasedStorageManager.NO_LOCKS
+            ) {
+                override fun isExpect(): Boolean = isExpect
+                override val annotations: Annotations = Annotations.create(listOfNotNull(experimentalAnnotation))
+            }.apply {
+                this.initialize(MemberScope.Empty, emptySet(), null)
+            }
+        }
+
+        override fun getContributedClassifier(name: Name, location: LookupLocation) = declarations(name)
+
+        override fun printScopeStructure(p: Printer) {
+            p.println(this::class.java.simpleName, "{}")
+        }
+    }
+
+    override fun getMemberScope(): MemberScope = memberScope
+}

--- a/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.KotlinLibraryProperResolverWithAttributes
 import org.jetbrains.kotlin.library.impl.createKotlinLibraryComponents
-import org.jetbrains.kotlin.library.metadata.KlibMetadataFactories
 import org.jetbrains.kotlin.library.metadata.NullFlexibleTypeDeserializer
 import org.jetbrains.kotlin.library.metadata.resolver.impl.KotlinLibraryResolverImpl
 import org.jetbrains.kotlin.library.metadata.resolver.impl.libraryResolver
@@ -18,7 +17,7 @@ import org.jetbrains.kotlin.library.resolveSingleFileKlib
 import org.jetbrains.kotlin.library.unresolvedDependencies
 import org.jetbrains.kotlin.storage.StorageManager
 import org.jetbrains.kotlin.util.Logger
-import java.io.*
+import java.io.File
 import org.jetbrains.kotlin.konan.file.File as KonanFile
 
 internal enum class KlibResolver { JS, Native }
@@ -29,11 +28,21 @@ internal fun KlibResolver.createModuleDescriptor(
     inputDependencies: Set<File>,
     storageManager: StorageManager
 ): ModuleDescriptor {
-    val factories = klibMetadataFactories()
+    val deserializedDescriptorFactory = CopyKlibMetadataModuleDescriptorFactoryImpl(
+        packageFragmentsFactory = CopyKlibMetadataDeserializedPackageFragmentsFactoryImpl(),
+        flexibleTypeDeserializer = when (this) {
+            KlibResolver.JS -> DynamicTypeDeserializer
+            KlibResolver.Native -> NullFlexibleTypeDeserializer
+        }
+    )
+
+    val defaultResolvedDescriptorsFactory = CopyKlibResolvedModuleDescriptorsFactoryImpl(
+        deserializedDescriptorFactory
+    )
 
     val library = resolveSingleFileKlib(KonanFile(lib.canonicalPath))
 
-    val module = factories.DefaultDeserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
+    val module = deserializedDescriptorFactory.createDescriptorOptionalBuiltIns(
         library,
         LanguageVersionSettingsImpl.DEFAULT,
         storageManager,
@@ -48,7 +57,7 @@ internal fun KlibResolver.createModuleDescriptor(
         noDefaultLibs = this == KlibResolver.JS,
         noEndorsedLibs = this == KlibResolver.JS
     )
-    val dependenciesResolved = factories.DefaultResolvedDescriptorsFactory.createResolved(
+    val dependenciesResolved = defaultResolvedDescriptorsFactory.createResolved(
         dependencies,
         storageManager,
         DefaultBuiltIns.Instance,
@@ -66,15 +75,6 @@ internal fun KlibResolver.createModuleDescriptor(
     module.setDependencies(listOf(module) + dependenciesDescriptors + forwardDeclarationsModule)
     return module
 }
-
-@RequiresKotlinCompilerEmbeddable
-private fun KlibResolver.klibMetadataFactories() = KlibMetadataFactories(
-    createBuiltIns = { DefaultBuiltIns.Instance },
-    flexibleTypeDeserializer = when (this) {
-        KlibResolver.JS -> DynamicTypeDeserializer
-        KlibResolver.Native -> NullFlexibleTypeDeserializer
-    }
-)
 
 @RequiresKotlinCompilerEmbeddable
 private fun KlibResolver.libraryResolver(inputDependencies: Set<File>): KotlinLibraryResolverImpl<KotlinLibrary> {

--- a/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
+++ b/plugin/main/src/kotlinx/benchmark/gradle/KlibResolver.kt
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.backend.common.serialization.metadata.DynamicTypeDes
 import org.jetbrains.kotlin.builtins.DefaultBuiltIns
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.konan.library.KLIB_INTEROP_IR_PROVIDER_IDENTIFIER
 import org.jetbrains.kotlin.library.KotlinLibrary
 import org.jetbrains.kotlin.library.KotlinLibraryProperResolverWithAttributes
@@ -47,8 +46,7 @@ internal fun KlibResolver.createModuleDescriptor(
         LanguageVersionSettingsImpl.DEFAULT,
         storageManager,
         DefaultBuiltIns.Instance,
-        null,
-        LookupTracker.DO_NOTHING
+        null
     )
 
     val dependencies = libraryResolver(inputDependencies).resolveWithDependencies(


### PR DESCRIPTION
This PR is part of the fix for [KT-87387](https://youtrack.jetbrains.com/issue/KT-87387). Kotlin compiler team will remove `KlibMetadataFactories` and all descriptor factories. Right now the only known external user of these factories is `kotlinx-benchmark` project. The easiest way to fix it – inline all the usages. Later on, all such usages should be fixed by [KT-82882](https://youtrack.jetbrains.com/issue/KT-82882).

I did this change in separate digestible commits. Please tell me if you want to squash then before merging.