### PR TITLE
Temporary remove dependency on build /w master from all tests

### DIFF
--- a/.teamcity/additionalConfiguration.kt
+++ b/.teamcity/additionalConfiguration.kt
@@ -35,7 +35,9 @@ fun Project.additionalConfiguration() {
 
     // Check with Kotlin master only on Linux
     buildWithKotlinMaster(Platform.Linux, knownBuilds.buildVersion).also {
-        knownBuilds.buildAll.dependsOnSnapshot(it, onFailure = FailureAction.ADD_PROBLEM)
+        // Temprary disabled: watchosArm32 target was removed in 2.5.0,
+        // but the plugin's runtime is still build and released for it.
+        // knownBuilds.buildAll.dependsOnSnapshot(it, onFailure = FailureAction.ADD_PROBLEM)
     }
 }
 


### PR DESCRIPTION
watchosArm32 target was removed in 2.5.0,
but the plugin's runtime is still build and released for it.

As a result, build w/ master is constantly failing.