### PR TITLE
Workaround watchosArm32 target removal in Kotlin 2.5

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -15,6 +15,12 @@ repositories {
     mavenCentral()
 }
 
+// Temporary workaround for the removed watchosArm32 target
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+fun KotlinMultiplatformExtension.watchosArm32() {
+    // Do nothing
+}
+
 kotlin {
     jvmToolchain(17)
 


### PR DESCRIPTION
Adds a stub function to call instead of the removed `watchosArm32()` when building the projects with fresh Kotlin versions.