### PR TITLE
Update minSupportedGradleVersion to 8.14.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ gradle-pluginPublish = "2.1.1"
 ksp = "2.3.11"
 
 # Note: This version can be overridden by passing `-Pmin_supported_gradle_version=<version>`
-minSupportedGradle = "8.0"
+minSupportedGradle = "8.14.5"
 minSupportedKotlin = "2.2.0"
 
 [libraries]

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/GradleTestVersion.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/GradleTestVersion.kt
@@ -1,7 +1,7 @@
 package kotlinx.benchmark.integration
 
 enum class GradleTestVersion(val versionString: String) {
-    v8_14_5("8.14.5"),
+    v8_0("8.0.2"),
     MinSupportedGradleVersion(System.getProperty("minSupportedGradleVersion")),
     UnsupportedGradleVersion("7.3"),
     v9_3_0("9.3.0"),

--- a/integration/src/main/kotlin/kotlinx/benchmark/integration/GradleTestVersion.kt
+++ b/integration/src/main/kotlin/kotlinx/benchmark/integration/GradleTestVersion.kt
@@ -1,7 +1,7 @@
 package kotlinx.benchmark.integration
 
 enum class GradleTestVersion(val versionString: String) {
-    v8_0("8.0.2"),
+    v8_14_5("8.14.5"),
     MinSupportedGradleVersion(System.getProperty("minSupportedGradleVersion")),
     UnsupportedGradleVersion("7.3"),
     v9_3_0("9.3.0"),


### PR DESCRIPTION
Follow-up to d69b7d162027e4ea4ba24dc496fdf16ded8a8857 that sets minSupportedGradleVersion to 8.14.5 to be compatible with the upcoming Kotlin 2.5.0 release. Also updates Gradle version in integration tests so they can run against Kotlin 2.5.0.