### PR TITLE
Removed workaround for KT-58063

### DIFF
--- a/integration/src/test/kotlin/kotlinx/benchmark/integration/ConfigurationCacheTest.kt
+++ b/integration/src/test/kotlin/kotlinx/benchmark/integration/ConfigurationCacheTest.kt
@@ -5,8 +5,7 @@ import kotlin.test.*
 
 class ConfigurationCacheTest : GradleTest() {
     private fun runConfigurationCacheTest(projectName: String, invokedTasks: List<String>, executedTasks: List<String>) {
-        val project = project(projectName, gradleVersion = GradleTestVersion.v8_0) {
-            // this test doesn't pass for K/N on Gradle 8.1 yet: https://youtrack.jetbrains.com/issue/KT-58063
+        val project = project(projectName) {
             configuration("main") {
                 warmups = 1
                 iterations = 1


### PR DESCRIPTION
KT-58063 is long fixed, the affected test don't have to use Gradle 8.0